### PR TITLE
Add PyProject Release and enforce flash-attention at runtime

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: Apache-2.0
+
+name: Build, test, and upload PyPI package
+
+on:
+    push:
+        branches:
+            - "main"
+            - "release-**"
+        tags:
+            - "v*"
+    pull_request:
+        branches:
+            - "main"
+            - "release-**"
+    release:
+        types:
+            - published
+
+env:
+    LC_ALL: en_US.UTF-8
+
+defaults:
+    run:
+        shell: bash
+
+permissions:
+    contents: read
+
+jobs:
+    # Create and verify release artifacts
+    # - build source dist (tar ball) and wheel
+    # - validate artifacts with various tools
+    # - upload artifacts to GHA
+    build-package:
+        name: Build and check packages
+        runs-on: ubuntu-latest
+        steps:
+            - name: "Harden Runner"
+              uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+              with:
+                  egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+
+
+            - name: "Checkout"
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+              with:
+                  # for setuptools-scm
+                  fetch-depth: 0
+
+            - name: "Build and Inspect"
+              uses: hynek/build-and-inspect-python-package@c52c3a4710070b50470d903818a7b25115dcd076 # v2.13.0
+
+    # push to Test PyPI on
+    # - a new GitHub release is published
+    # - a PR is merged into main branch
+    publish-test-pypi:
+        name: Publish packages to test.pypi.org
+        environment: testpypi
+        if: ${{ (github.event.action == 'published') || ((github.event_name == 'push') && (github.ref == 'refs/heads/main')) }}
+        permissions:
+            contents: read
+            # see https://docs.pypi.org/trusted-publishers/
+            id-token: write
+        runs-on: ubuntu-latest
+        needs: build-package
+
+        steps:
+            - name: "Harden Runner"
+              uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+              with:
+                  egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+
+            - name: "Download build artifacts"
+              uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+              with:
+                  name: Packages
+                  path: dist
+
+            - name: "Upload to Test PyPI"
+              uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
+              with:
+                  repository-url: https://test.pypi.org/legacy/
+
+    # push to Production PyPI on
+    # - a new GitHub release is published
+    publish-pypi:
+        name: Publish release to pypi.org
+        environment: pypi
+        if: ${{ (github.event.action == 'published') }}
+        permissions:
+            # see https://docs.pypi.org/trusted-publishers/
+            id-token: write
+            # allow gh release upload
+            contents: write
+
+        runs-on: ubuntu-latest
+        needs: build-package
+
+        steps:
+            - name: "Harden Runner"
+              uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+              with:
+                  egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+
+            - name: "Download build artifacts"
+              uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+              with:
+                  name: Packages
+                  path: dist
+
+            - name: "Sigstore sign package"
+              uses: sigstore/gh-action-sigstore-python@f7ad0af51a5648d09a20d00370f0a91c3bdf8f84 # v3.0.1
+              with:
+                  inputs: |
+                      ./dist/*.tar.gz
+                      ./dist/*.whl
+                  release-signing-artifacts: false
+
+            - name: "Upload artifacts and signatures to GitHub release"
+              run: |
+                  gh release upload '${{ github.ref_name }}' dist/* --repo '${{ github.repository }}'
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+            # PyPI does not accept .sigstore artifacts and
+            # gh-action-pypi-publish has no option to ignore them.
+            - name: "Remove sigstore signatures before uploading to PyPI"
+              run: |
+                  rm ./dist/*.sigstore.json
+
+            - name: "Upload to PyPI"
+              uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+# version file
+src/mini_trainer/_version.py
+
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+
 [build-system]
-requires = ["setuptools>=61.0", "wheel", "torch>=2.6", "ninja"]
+requires = ["setuptools>=64.0", "wheel", "torch>=2.6", "ninja", "setuptools_scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "mini_trainer"
-version = "0.1.0"
+name = "rhai-innovation-mini-trainer"
+dynamic = ["version"] 
 description = "Simple training repo which is used to house reference implementations of emerging training algorithms, such as Orthogonal Subspace Fine Tuning (OSFT)."
 readme = "Readme.md"
 requires-python = ">=3.11,<3.13"
@@ -86,3 +88,9 @@ markers = [
     "gpu: marks tests that require GPU",
     "multi_gpu: marks tests that require multiple GPUs",
 ]
+
+# for dynamic versioning
+[tool.setuptools_scm]
+version_file = "src/mini_trainer/_version.py"
+# do not include +gREV local version, required for Test PyPI upload
+local_scheme = "no-local-version"

--- a/src/mini_trainer/__init__.py
+++ b/src/mini_trainer/__init__.py
@@ -4,7 +4,13 @@ This package provides reference implementations of emerging training algorithms,
 including Orthogonal Subspace Fine Tuning (OSFT).
 """
 
-__version__ = "0.1.0"
+# Dynamic version from setuptools_scm
+try:
+    from ._version import __version__
+except ImportError:
+    # Fallback for development installations
+    __version__ = "unknown"
+
 
 from . import api_train
 from . import async_structured_logger

--- a/tests/test_api_train.py
+++ b/tests/test_api_train.py
@@ -101,6 +101,7 @@ class TestDataclasses:
 
 class TestStreamablePopen:
     """Test the StreamablePopen wrapper."""
+    buffer_time = 1.0 # seconds
     
     def test_streamable_popen_success(self):
         """Test StreamablePopen with successful command."""
@@ -205,9 +206,9 @@ class TestStreamablePopen:
             command = ["python", "-c", 
                       "import time, sys; "
                       "print('1', flush=True); "
-                      "time.sleep(0.5); "
+                      f"time.sleep({self.buffer_time}); "
                       "print('2', flush=True); "
-                      "time.sleep(0.5); "
+                      f"time.sleep({self.buffer_time}); "
                       "print('3', flush=True)"]
             
             popen = StreamablePopen(str(log_file), command)
@@ -217,28 +218,31 @@ class TestStreamablePopen:
             listen_thread.start()
             
             # Check that "1" appears first
-            time.sleep(0.2)  # Give it time to start and print "1"
+            time.sleep(self.buffer_time)  # Increased delay for CI environments to start subprocess
             with open(log_file) as f:
                 content = f.read()
-                assert "1" in content
+                print(f"DEBUG: After {self.buffer_time}s, file content: {repr(content)}")
+                assert "1" in content, f"Expected '1' in content but got: {repr(content)}"
                 assert "2" not in content
                 assert "3" not in content
             
             # Check that "2" appears next
-            time.sleep(0.5)  # Wait for "2" to be printed
+            time.sleep(self.buffer_time)  # Wait for "2" to be printed
             with open(log_file) as f:
                 content = f.read()
+                print(f"DEBUG: After {self.buffer_time *2}s, file content: {repr(content)}")
                 assert "1" in content
-                assert "2" in content
+                assert "2" in content, f"Expected '2' in content but got: {repr(content)}"
                 assert "3" not in content
             
             # Check that "3" appears last
-            time.sleep(0.5)  # Wait for "3" to be printed
+            time.sleep(self.buffer_time)  # Wait for "3" to be printed
             with open(log_file) as f:
                 content = f.read()
+                print(f"DEBUG: After {self.buffer_time * 3}s, file content: {repr(content)}")
                 assert "1" in content
                 assert "2" in content
-                assert "3" in content
+                assert "3" in content, f"Expected '3' in content but got: {repr(content)}"
             
             listen_thread.join()
             assert popen.poll() == 0
@@ -254,9 +258,9 @@ class TestStreamablePopen:
             command = ["python", "-c", 
                       "import time, sys; "
                       "print('1', file=sys.stderr, flush=True); "
-                      "time.sleep(0.5); "
+                      f"time.sleep({self.buffer_time}); "
                       "print('2', file=sys.stderr, flush=True); "
-                      "time.sleep(0.5); "
+                      f"time.sleep({self.buffer_time}); "
                       "print('3', file=sys.stderr, flush=True)"]
             
             popen = StreamablePopen(str(log_file), command)
@@ -266,28 +270,31 @@ class TestStreamablePopen:
             listen_thread.start()
             
             # Check that "1" appears first
-            time.sleep(0.2)  # Give it time to start and print "1"
+            time.sleep(self.buffer_time)  # Increased delay for CI environments to start subprocess
             with open(log_file) as f:
                 content = f.read()
-                assert "1" in content
+                print(f"DEBUG stderr test: After {self.buffer_time}s, file content: {repr(content)}")
+                assert "1" in content, f"Expected '1' in content but got: {repr(content)}"
                 assert "2" not in content
                 assert "3" not in content
             
             # Check that "2" appears next
-            time.sleep(0.5)  # Wait for "2" to be printed
+            time.sleep(self.buffer_time)  # Wait for "2" to be printed
             with open(log_file) as f:
                 content = f.read()
+                print(f"DEBUG stderr test: After {self.buffer_time * 2}s, file content: {repr(content)}")
                 assert "1" in content
-                assert "2" in content
+                assert "2" in content, f"Expected '2' in content but got: {repr(content)}"
                 assert "3" not in content
             
             # Check that "3" appears last
-            time.sleep(0.5)  # Wait for "3" to be printed
+            time.sleep(self.buffer_time)  # Wait for "3" to be printed
             with open(log_file) as f:
                 content = f.read()
+                print(f"DEBUG stderr test: After {self.buffer_time * 3}s, file content: {repr(content)}")
                 assert "1" in content
                 assert "2" in content
-                assert "3" in content
+                assert "3" in content, f"Expected '3' in content but got: {repr(content)}"
             
             listen_thread.join()
             assert popen.poll() == 0
@@ -303,11 +310,11 @@ class TestStreamablePopen:
             command = ["python", "-c", 
                       "import time, sys; "
                       "print('stdout-1', flush=True); "
-                      "time.sleep(0.3); "
+                      f"time.sleep({self.buffer_time}); "
                       "print('stderr-1', file=sys.stderr, flush=True); "
-                      "time.sleep(0.3); "
+                      f"time.sleep({self.buffer_time}); "
                       "print('stdout-2', flush=True); "
-                      "time.sleep(0.3); "
+                      f"time.sleep({self.buffer_time}); "
                       "print('stderr-2', file=sys.stderr, flush=True)"]
             
             popen = StreamablePopen(str(log_file), command)
@@ -317,40 +324,44 @@ class TestStreamablePopen:
             listen_thread.start()
             
             # Check first stdout appears
-            time.sleep(0.15)
+            time.sleep(self.buffer_time)  # Increased initial delay for CI environments
             with open(log_file) as f:
                 content = f.read()
-                assert "stdout-1" in content
+                print(f"DEBUG mixed test: After {self.buffer_time}s, file content: {repr(content)}")
+                assert "stdout-1" in content, f"Expected 'stdout-1' in content but got: {repr(content)}"
                 assert "stderr-1" not in content
                 assert "stdout-2" not in content
                 assert "stderr-2" not in content
             
             # Check first stderr appears
-            time.sleep(0.3)
+            time.sleep(self.buffer_time)
             with open(log_file) as f:
                 content = f.read()
+                print(f"DEBUG mixed test: After {self.buffer_time * 2}s, file content: {repr(content)}")
                 assert "stdout-1" in content
-                assert "stderr-1" in content
+                assert "stderr-1" in content, f"Expected 'stderr-1' in content but got: {repr(content)}"
                 assert "stdout-2" not in content
                 assert "stderr-2" not in content
             
             # Check second stdout appears
-            time.sleep(0.3)
+            time.sleep(self.buffer_time)
             with open(log_file) as f:
                 content = f.read()
+                print(f"DEBUG mixed test: After {self.buffer_time * 3}s, file content: {repr(content)}")
                 assert "stdout-1" in content
                 assert "stderr-1" in content
-                assert "stdout-2" in content
+                assert "stdout-2" in content, f"Expected 'stdout-2' in content but got: {repr(content)}"
                 assert "stderr-2" not in content
             
             # Check second stderr appears
-            time.sleep(0.3)
+            time.sleep(self.buffer_time)  # Increased delay to ensure last output is written
             with open(log_file) as f:
                 content = f.read()
+                print(f"DEBUG mixed test: After {self.buffer_time * 4}s, file content: {repr(content)}")
                 assert "stdout-1" in content
                 assert "stderr-1" in content
                 assert "stdout-2" in content
-                assert "stderr-2" in content
+                assert "stderr-2" in content, f"Expected 'stderr-2' in content but got: {repr(content)}"
             
             listen_thread.join()
             assert popen.poll() == 0

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ deps =
 setenv = 
     # Clear CUDA for non-GPU tests
     nogpu: CUDA_VISIBLE_DEVICES = 
-    
+    TESTING=true
 passenv = 
     # GPU tests need CUDA environment variables
     gpu: CUDA_VISIBLE_DEVICES

--- a/tox.ini
+++ b/tox.ini
@@ -55,8 +55,8 @@ commands =
     gpu-cov: pytest tests/gpu_tests -v --tb=short -p no:xdist --cov=src/mini_trainer --cov-report=term-missing --cov-report=xml --cov-report=html  {posargs}
     
     # Non-GPU tests (only when 'nogpu' factor is present)
-    nogpu-!cov: pytest tests/ -m "not gpu and not multi_gpu" --ignore=tests/gpu_tests/ -v -p no:xdist --tb=short {posargs}
-    nogpu-cov: pytest tests/ -m "not gpu and not multi_gpu" --ignore=tests/gpu_tests/ -v -p no:xdist --tb=short --cov=src/mini_trainer --cov-report=term-missing --cov-report=xml --cov-report=html {posargs}
+    nogpu-!cov: pytest tests/ -m "not gpu and not multi_gpu" --ignore=tests/gpu_tests/ -v -s -p no:xdist --tb=short {posargs}
+    nogpu-cov: pytest tests/ -m "not gpu and not multi_gpu" --ignore=tests/gpu_tests/ -v -s -p no:xdist --tb=short --cov=src/mini_trainer --cov-report=term-missing --cov-report=xml --cov-report=html {posargs}
     
     # Default tests (when neither gpu nor nogpu factors are present)
     !gpu-!nogpu-!cov: pytest {posargs} -p no:xdist


### PR DESCRIPTION
This PR adds a workflow for releasing the mini_trainer project as a Python package.
It also forces flash-attention to be mandatory except during testing environments. 