### PR TITLE
add port to default rdzv_endpoint

### DIFF
--- a/src/mini_trainer/training_types.py
+++ b/src/mini_trainer/training_types.py
@@ -25,7 +25,7 @@ class TorchrunArgs:
     nproc_per_node: int = 1
     node_rank: int = 0
     rdzv_id: int = 123
-    rdzv_endpoint: str = "127.0.0.1"
+    rdzv_endpoint: str = "127.0.0.1:1738"
 
 
 @dataclass

--- a/tests/test_api_train.py
+++ b/tests/test_api_train.py
@@ -28,7 +28,7 @@ class TestDataclasses:
         assert args.nproc_per_node == 1
         assert args.node_rank == 0
         assert args.rdzv_id == 123
-        assert args.rdzv_endpoint == "127.0.0.1"
+        assert args.rdzv_endpoint == "127.0.0.1:1738"
         
         # Test with custom nproc_per_node only
         args = TorchrunArgs(nproc_per_node=8)


### PR DESCRIPTION
This PR updates the Torchrun defaults so the endpoint has a port set
