### PR TITLE
add cpu offloading during checkpointing

### DIFF
--- a/src/mini_trainer/api_train.py
+++ b/src/mini_trainer/api_train.py
@@ -131,6 +131,9 @@ def run_training(torch_args: TorchrunArgs, train_args: TrainingArgs) -> None:
     
     if train_args.save_final_checkpoint:
         command.append("--save-final-checkpoint")
+ 
+    if train_args.save_dtype:
+        command.append(f"--save-dtype={train_args.save_dtype}")
     
     logger.info("Running training command as subprocess: %s", " ".join(command))
     

--- a/src/mini_trainer/osft_utils.py
+++ b/src/mini_trainer/osft_utils.py
@@ -1067,7 +1067,8 @@ def create_osft_model_class(base_cls) -> type[OSFTModel]:
             log_rank_0("Reconstructing OSFT weights for checkpoint saving...")
             
             # Process parameters one at a time to minimize peak memory usage
-            for i, (orig, safe) in enumerate(self.name_mapping.items()):
+            from tqdm import tqdm
+            for i, (orig, safe) in enumerate(tqdm(self.name_mapping.items(), desc="Reconstructing OSFT weights, this may take a while...", disable=torch.distributed.get_rank() != 0)):
                 # Extract SVD components
                 U_high = state_dict.pop(f"{safe}_U_high")
                 S_high = state_dict.pop(f"{safe}_S_high")

--- a/src/mini_trainer/setup_model_for_training.py
+++ b/src/mini_trainer/setup_model_for_training.py
@@ -8,7 +8,7 @@ from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
     checkpoint_wrapper as ptd_checkpoint_wrapper,
 )
 from torch.distributed.device_mesh import init_device_mesh
-from transformers import AutoTokenizer, AutoModelForCausalLM
+from transformers import AutoTokenizer, AutoModelForCausalLM, AutoConfig
 from mini_trainer.utils import log_rank_0, patch_target_module
 from mini_trainer.osft_utils import OSFTModel
 
@@ -96,18 +96,83 @@ def align_model_and_tokenizer(model, tokenizer):
     return model
 
 
+def get_model_save_dtype(save_dtype: str | torch.dtype | None, model_name_or_path: str) -> torch.dtype:
+    """
+    Given an HF model reference and an optional user-provided save_dtype, returns the PyTorch data type that it should
+    be saved in.
+
+    If the user does not provide a save_dtype, we will use the model's original dtype.
+    However; if the data-type is not in the supported list, we will raise an error.
+
+    If both the model `torch_dtype` and user-provided `save_dtype` are missing,
+    we default to saving in BF16.
+
+    Args:
+        save_dtype (str | None): The dtype we should be saving the model as.
+        model_name_or_path (str): The name or path of the model to load.
+    Returns:
+        The PyTorch data type that the model should be saved in.
+
+    """
+    dtype_map = {
+        "float32": torch.float32,
+        "float": torch.float32,
+        "float64": torch.float64,
+        "double": torch.float64,
+        "float16": torch.float16,
+        "half": torch.float16,
+        "bfloat16": torch.bfloat16,
+    }
+    default_dtype = torch.bfloat16
+    
+    # FSDP2 requires us to load the model in FP32 to begin with for the
+    # correct mixed-precision settings. So to circumvent this, we load the 
+    # original model's config separately 
+    original_config = AutoConfig.from_pretrained(model_name_or_path)
+    original_dtype = getattr(original_config, "torch_dtype", None)
+    
+    # HF models return a torch.dtype from this field, but docs mark it as an optional string
+    if original_dtype is not None and isinstance(original_dtype, str):
+        original_dtype = dtype_map[original_dtype]
+
+    # this handles the case when save_dtype > original_dtype > bf16
+    if not original_dtype and not save_dtype:
+        log_rank_0(f"⚠️ Model does not have a setting for `torch_dtype` and not `save_dtype` was provided, falling back to '{default_dtype}'")
+        return default_dtype
+
+    # handles the case save_dtype > original_dtype
+    if not save_dtype:
+        return original_dtype
+    
+    # by now we know that we are going to use a custom data type, so we just validate
+    if not isinstance(save_dtype, (str, torch.dtype)):
+        raise ValueError(f"error: could not recognize '{save_dtype}' as a supported dtype for saving model checkpoints")
+ 
+    # convert dtype to a str
+    if isinstance(save_dtype, str):
+        if save_dtype not in dtype_map:
+            raise ValueError(f"error: could not recognize '{save_dtype}' as a supported dtype for saving model checkpoints")
+        save_dtype = dtype_map[save_dtype]
+    
+    # alert the user when the dtype differs
+    if original_dtype and original_dtype != save_dtype:
+        log_rank_0(f"⚠️ Model's original dtype is '{original_dtype}', but new checkpoints will be saved as '{save_dtype}'. ⚠️")
+    return save_dtype
+
+
 def setup_model(
-    model=None,
+    model_name_or_path: str,
     osft: bool = False,
     rank: int = 0,
-    upcast_dtype: torch.dtype = torch.float32,
-    output_dtype: torch.dtype | None = None,
+    save_dtype: str | torch.dtype | None = None,
+    osft_upcast_dtype: torch.dtype = torch.float32,
+    osft_output_dtype: torch.dtype | None = None,
     osft_rank_ratio: float | None = None,
     osft_target_patterns: list[str] | None = None,
-    **kwargs,
+    use_liger_kernels: bool = False,
 ) -> torch.nn.Module | OSFTModel:
     base_model_args = {
-        "pretrained_model_name_or_path": kwargs['model_name_or_path'],
+        "pretrained_model_name_or_path": model_name_or_path,
     }
     # Check if flash_attn is available, otherwise use eager
     # in practice we will need flash attention when running this repo
@@ -120,9 +185,9 @@ def setup_model(
         else:
             raise e
 
-    tokenizer = AutoTokenizer.from_pretrained(kwargs["model_name_or_path"])
+    tokenizer = AutoTokenizer.from_pretrained(model_name_or_path)
 
-    if kwargs.get("use_liger_kernels", False):
+    if use_liger_kernels:
         """need to patch the loss function to not reduce, so we can reduce across all GPUs"""
         from mini_trainer.none_reduction_losses import (
             liger_fixed_fused_linear_cross_entropy_none_reduction,
@@ -173,9 +238,9 @@ def setup_model(
         
         # we need to set these as attributes because HF Transformers
         # doesn't like torch.dtype to be passed in through kwargs (aside from the `torch_dtype` kwarg)
-        model.upcast_dtype = upcast_dtype
-        if output_dtype:
-            model.output_dtype = output_dtype
+        model.upcast_dtype = osft_upcast_dtype
+        if osft_output_dtype:
+            model.output_dtype = osft_output_dtype
 
         model = align_model_and_tokenizer(model, tokenizer)
         device = torch.device("cuda", rank)
@@ -208,6 +273,11 @@ def setup_model(
     # Choose whether to apply orthogonal subspace learning (OSL) based on `osft` flag
     # OSL enables continual fine-tuning by constraining updates to low-rank directions orthogonal to critical knowledge that is to be preserved
     model = load_osft_model() if osft else load_standard_model()
+
+    # here we handle configuring the save_dtype
+    model.config.torch_dtype = get_model_save_dtype(save_dtype, model_name_or_path)
+    if not model.config.torch_dtype:
+        raise ValueError("error: model does not have a `torch_dtype` setting, cannot save model in this dtype")
 
     if model.__class__.__name__ not in [
         "MistralForCausalLM",

--- a/src/mini_trainer/train.py
+++ b/src/mini_trainer/train.py
@@ -21,16 +21,48 @@ app = Typer(
     pretty_exceptions_short=True   
 )
 
+def validate_fp32_training_state(model, optimizer):
+    """
+    Validates that the model, optimizer, and gradients are all in FP32.
+    """
+    for name, param in model.named_parameters():
+        if param.dtype != torch.float32:
+            raise ValueError(f"Parameter {name} is not in FP32")
+    for name, param in optimizer.state.items():
+        for k, v in param.items():
+            if v.dtype != torch.float32: 
+                raise ValueError(f"Optimizer state {name}.{k} is not in FP32")
+    for name, grad in model.named_parameters():
+        if grad.dtype != torch.float32:
+            raise ValueError(f"Gradient {name} is not in FP32")
+
+
 def take_gradient_step(model, optimizer, lr_scheduler):
     """Scales gradients, applies clipping, and takes an optimization step."""
     grad_norm = torch.nn.utils.clip_grad_norm_(model.parameters(), 1.0)
     optimizer.step()
     lr_scheduler.step()
+    # keep this here in case mixed precision settings are ever broken
+    validate_fp32_training_state(model, optimizer)
     optimizer.zero_grad()
     return grad_norm
 
 
-def save_model(fsdp_model, samples_seen, output_dir, model_name_or_path):
+def save_model(
+    fsdp_model, 
+    samples_seen: int,
+    output_dir: str,
+    model_name_or_path: str,
+):
+    """
+    Save the given FSDP Model as a checkpoint in HF Format.
+
+    Args:
+        fsdp_model (str): The model to save.
+        samples_seen (int): The number of samples seen so far.
+        output_dir (str): The directory to save the model.
+        model_name_or_path (str): The model name or path.
+    """
     from huggingface_hub import split_torch_state_dict_into_shards
     from transformers import AutoTokenizer
     from safetensors.torch import save_file
@@ -58,10 +90,13 @@ def save_model(fsdp_model, samples_seen, output_dir, model_name_or_path):
             broadcast_from_rank0=False,
         )
     )
+    inner = getattr(fsdp_model, "module", fsdp_model)
+    # save in whatever data type is stored on the model config
+    # by now the `torch_dtype` attribute has been set to some value
+    save_dtype = inner.config.torch_dtype  
 
+    # Unfortunately this process takes quite a bit on the CPU.
     if rank == 0:
-        # Unfortunately this process takes quite a bit on the CPU.
-        inner = getattr(fsdp_model, "module", fsdp_model)
         if hasattr(inner, "prepare_state_dict_for_save"):
             state_dict = inner.prepare_state_dict_for_save(state_dict)
         
@@ -73,12 +108,12 @@ def save_model(fsdp_model, samples_seen, output_dir, model_name_or_path):
     notified_about_dtype = False
     cpu_device = torch.device('cpu')
     for k, v in state_dict.items():
-        if v.dtype != torch.bfloat16:
+        if v.dtype != save_dtype:
             if not notified_about_dtype:
-                log_rank_0(f"⚠️  Warning: Found tensor {k} with dtype {v.dtype}, casting to bfloat16")
+                log_rank_0(f"⚠️  Warning: Found tensor {k} with dtype {v.dtype}, casting to {save_dtype}")
                 notified_about_dtype = True
-            state_dict[k] = v.to(dtype=torch.bfloat16, device=cpu_device)
-    
+            state_dict[k] = v.to(dtype=save_dtype, device=cpu_device)
+ 
     if rank == 0:
         pattern = "model{suffix}.safetensors"
         index_name = "model.safetensors.index.json"
@@ -441,8 +476,6 @@ def calculate_num_training_steps(
     else:
         raise ValueError(f"Unknown training mode: {training_mode}")
 
-
-
 @app.command()
 def main(
     # the '...' is a way of defining required options/arguments without breaking Python's
@@ -468,7 +501,6 @@ def main(
     osft_upcast_dtype: Annotated[str | None, Option(help="Upcast dtype for OSFT computations. Can be 'float16', 'bfloat16', 'float32', etc.")] = "float32",
     osft_output_dtype: Annotated[str | None, Option(help="Output dtype for OSFT. If None, uses original model dtype. Can be 'float16', 'bfloat16', 'float32', etc.")] = None,
 
-
     output_dir: Annotated[str, Option(help="Directory to save checkpoints and logs (required)")] = ...,
     min_samples_per_checkpoint: Annotated[int | None, Option(help="Minimum number of samples processed before saving a checkpoint (required)")] = None,
 
@@ -479,8 +511,8 @@ def main(
     max_tokens: Annotated[int, Option(help="Maximum number of loss-counted tokens (for token mode)")] = 0,
     checkpoint_at_epoch: Annotated[bool, Option(help="Whether to save checkpoints at the end of each epoch")] = False,
     save_final_checkpoint: Annotated[bool, Option(help="Whether to save a final checkpoint when training ends")] = False,
+    save_dtype: Annotated[str | None, Option(help="Dtype to save the model in. If None, uses original model dtype. Can be 'float16', 'bfloat16', 'float32', etc.")] = None,
 ):
-    
     
     init_distributed_environment()
     # TODO: make the path creation lazy, but confirm that we can write to the given directory
@@ -520,6 +552,7 @@ def main(
             "osft_output_dtype": osft_output_dtype,
             "output_dir": output_dir,
             "min_samples_per_checkpoint": min_samples_per_checkpoint,
+            "save_dtype": save_dtype,
             "training_mode": training_mode.value,
             "max_epochs": max_epochs,
             "max_steps": max_steps,
@@ -571,6 +604,7 @@ def main(
     osft_rank_ratio = None if osft_unfreeze_rank_ratio is None else (1.0 - osft_unfreeze_rank_ratio)
     model = setup_model(
         model_name_or_path=model_name_or_path,
+        save_dtype=save_dtype,
         use_liger_kernels=use_liger_kernels,
         osft=osft,
         rank=rank,
@@ -596,6 +630,7 @@ def main(
         output_dir=output_dir,
         min_samples_per_checkpoint=min_samples_per_checkpoint,
         model_name_or_path=model_name_or_path,
+        save_dtype=save_dtype,
         training_mode=training_mode,
         max_epochs=max_epochs,
         max_steps=max_steps,

--- a/src/mini_trainer/train.py
+++ b/src/mini_trainer/train.py
@@ -29,6 +29,7 @@ def take_gradient_step(model, optimizer, lr_scheduler):
     optimizer.zero_grad()
     return grad_norm
 
+
 def save_model(fsdp_model, samples_seen, output_dir, model_name_or_path):
     from huggingface_hub import split_torch_state_dict_into_shards
     from transformers import AutoTokenizer
@@ -39,13 +40,44 @@ def save_model(fsdp_model, samples_seen, output_dir, model_name_or_path):
     rank = torch.distributed.get_rank()
     save_directory = Path(output_dir) / "hf_format" / f"samples_{samples_seen}"
     os.makedirs(save_directory, exist_ok=True)
-    # Get full state dict
+    
+    # NOTE(osilkin):
+    # Here, we gather the model's state-dict and offload it onto the CPU
+    # The downside with this approach is that it requires recomputing
+    # each OSFT parameter on the CPU.
+    # This can be optimized by modifying the `prepare_state_dict_for_save` function so that it
+    # processes weights on the GPU device in batches before de-allocating the memory being consumed
+    # Users may also face issues here if they lack the CPU memory required to store the original
+    # FP32 state dict on CPU.
     from torch.distributed.checkpoint.state_dict import get_model_state_dict, StateDictOptions
-    state_dict = get_model_state_dict(fsdp_model, options=StateDictOptions(full_state_dict=True))
-    inner = getattr(fsdp_model, "module", fsdp_model)
-    if hasattr(inner, "prepare_state_dict_for_save"):
-        state_dict = inner.prepare_state_dict_for_save(state_dict)
-    state_dict = {k: v.to(torch.bfloat16) for k, v in state_dict.items()}
+    state_dict = get_model_state_dict(
+        fsdp_model,
+        options=StateDictOptions(
+            full_state_dict=True,
+            cpu_offload=True,
+            broadcast_from_rank0=False,
+        )
+    )
+
+    if rank == 0:
+        # Unfortunately this process takes quite a bit on the CPU.
+        inner = getattr(fsdp_model, "module", fsdp_model)
+        if hasattr(inner, "prepare_state_dict_for_save"):
+            state_dict = inner.prepare_state_dict_for_save(state_dict)
+        
+    torch.distributed.barrier()
+
+    # Once we have all of our parameters, we need to ensure they're stored in BF16
+    # so checkpoints aren't terrible heavy. We have to do this _after_ `prepare_state_dict_for_save`
+    # has been called so we don't lose fidelity.
+    notified_about_dtype = False
+    cpu_device = torch.device('cpu')
+    for k, v in state_dict.items():
+        if v.dtype != torch.bfloat16:
+            if not notified_about_dtype:
+                log_rank_0(f"⚠️  Warning: Found tensor {k} with dtype {v.dtype}, casting to bfloat16")
+                notified_about_dtype = True
+            state_dict[k] = v.to(dtype=torch.bfloat16, device=cpu_device)
     
     if rank == 0:
         pattern = "model{suffix}.safetensors"
@@ -66,12 +98,13 @@ def save_model(fsdp_model, samples_seen, output_dir, model_name_or_path):
             index = {"metadata": split.metadata, "weight_map": split.tensor_to_filename}
             with open(os.path.join(save_directory, index_name), "w") as f:
                 json.dump(index, f, indent=2, sort_keys=True)
-        # Save config and tokenizer (unwrap inner module)
-        inner = getattr(fsdp_model, "module", fsdp_model)
+        # Save config and tokenizer
         inner.config.to_json_file(os.path.join(save_directory, "config.json"))
         tokenizer = AutoTokenizer.from_pretrained(model_name_or_path)
         tokenizer.save_pretrained(save_directory)
-        log_rank_0(f"\033[1;38;2;0;255;255mSaved model at\033[0m {samples_seen} samples in {time.time() - start:.2f} seconds")
+        log_rank_0(f"✅ Saved model at {samples_seen} samples in {time.time() - start:.2f} seconds")
+    
+    log_rank_0("")
     torch.distributed.barrier()
 
 def reached_stop_condition(
@@ -320,6 +353,7 @@ def train(
                         "time_per_batch": batch_time,
                         "tokens_per_second": bm['num_total_tokens']/batch_time,
                         "total_samples_accumulated": total_samples_accumulated, 
+                        "total_tokens_accumulated": total_tokens_processed,
                         "samples_per_second": bm['num_samples']/batch_time,
                         "peak_memory_usage_GB": float(torch.cuda.max_memory_allocated() / 1e9),
                     }

--- a/src/mini_trainer/training_types.py
+++ b/src/mini_trainer/training_types.py
@@ -77,4 +77,5 @@ class TrainingArgs:
     # Checkpointing
     checkpoint_at_epoch: bool = field(default=False, metadata={"help": "Whether to checkpoint at the end of each epoch."})
     save_final_checkpoint: bool = field(default=True, metadata={"help": "Whether the model should be saved at the end of training or not. Off by default to avoid accidentally overwriting the best checkpoint."})
+    save_dtype: str | None = field(default=None, metadata={"help": "The dtype to save the model in. If None, uses original model dtype. Can be 'float16', 'bfloat16', 'float32', etc."})
 

--- a/tests/test_model_initialization.py
+++ b/tests/test_model_initialization.py
@@ -177,8 +177,9 @@ class TestSetupModel:
     
     @patch('mini_trainer.setup_model_for_training.AutoTokenizer.from_pretrained')
     @patch('mini_trainer.setup_model_for_training.AutoModelForCausalLM.from_pretrained')
+    @patch('mini_trainer.setup_model_for_training.AutoConfig.from_pretrained')
     @patch('mini_trainer.setup_model_for_training.align_model_and_tokenizer')
-    def test_setup_model_standard(self, mock_align, mock_model_cls, mock_tokenizer_cls):
+    def test_setup_model_standard(self, mock_align, auto_config, mock_model_cls, mock_tokenizer_cls):
         """Test standard model setup without special features."""
         mock_tokenizer = MagicMock()
         mock_tokenizer_cls.return_value = mock_tokenizer
@@ -316,52 +317,56 @@ class TestIntegration:
     
     def test_end_to_end_mock(self):
         """Test end-to-end flow with mocks."""
-        with patch('mini_trainer.setup_model_for_training.AutoTokenizer.from_pretrained') as mock_tok:
-            with patch('mini_trainer.setup_model_for_training.AutoModelForCausalLM.from_pretrained') as mock_model_cls:
-                with patch('mini_trainer.setup_model_for_training.wrap_fsdp2') as mock_wrap:
-                    with patch('mini_trainer.setup_model_for_training.log_rank_0'):
-                        mock_tokenizer = MagicMock()
-                        mock_tokenizer.__len__ = MagicMock(return_value=32000)  # Set proper length
-                        mock_tok.return_value = mock_tokenizer
-                        
-                        mock_model = MagicMock()
-                        mock_model.__class__.__name__ = "LlamaForCausalLM"
-                        mock_model.config = MagicMock()
-                        mock_model.config.vocab_size = 32000
-                        mock_model.parameters = MagicMock(return_value=[MagicMock()])
-                        mock_model_cls.return_value = mock_model
-                        
-                        mock_wrap.return_value = mock_model
-                        
-                        # Setup model
-                        model = setup_model(
-                            model_name_or_path="test/model",
-                            use_liger_kernels=False,
-                            osft=False,
-                            rank=0
-                        )
-                        
-                        # Setup training components
-                        with patch('mini_trainer.setup_model_for_training.torch.optim.AdamW') as mock_adamw:
-                            with patch('transformers.get_scheduler') as mock_sched:
-                                with patch('mini_trainer.osft_utils.optim_wrapper') as mock_opt_wrap:
-                                    mock_optimizer = MagicMock()
-                                    mock_adamw.return_value = mock_optimizer
-                                    mock_opt_wrap.return_value = mock_optimizer
-                                    
-                                    mock_scheduler = MagicMock()
-                                    mock_sched.return_value = mock_scheduler
-                                    
-                                    model, optimizer, scheduler = setup_training_components(
-                                        model,
-                                        learning_rate=1e-5,
-                                        num_warmup_steps=10,
-                                        lr_scheduler="constant"
-                                    )
-                                    
-                                    assert model is not None
-                                    assert optimizer is not None
-                                    assert scheduler is not None
+        with (
+            patch('mini_trainer.setup_model_for_training.AutoTokenizer.from_pretrained') as mock_tok,
+            patch('mini_trainer.setup_model_for_training.AutoModelForCausalLM.from_pretrained') as mock_model_cls,
+            patch('mini_trainer.setup_model_for_training.AutoConfig.from_pretrained') as mock_config,
+            patch('mini_trainer.setup_model_for_training.wrap_fsdp2') as mock_wrap,
+            patch('mini_trainer.setup_model_for_training.log_rank_0'),
+            patch('mini_trainer.setup_model_for_training.torch.optim.AdamW') as mock_adamw,
+            patch('transformers.get_scheduler') as mock_sched,
+            patch('mini_trainer.osft_utils.optim_wrapper') as mock_opt_wrap
+        ):
+            # Setup tokenizer mock
+            mock_tokenizer = MagicMock()
+            mock_tokenizer.__len__ = MagicMock(return_value=32000)
+            mock_tok.return_value = mock_tokenizer
+            
+            # Setup model mock
+            mock_model = MagicMock()
+            mock_model.__class__.__name__ = "LlamaForCausalLM"
+            mock_model.config = MagicMock()
+            mock_model.config.vocab_size = 32000
+            mock_model.parameters = MagicMock(return_value=[MagicMock()])
+            mock_model_cls.return_value = mock_model
+            mock_wrap.return_value = mock_model
+            
+            # Setup optimizer and scheduler mocks
+            mock_optimizer = MagicMock()
+            mock_adamw.return_value = mock_optimizer
+            mock_opt_wrap.return_value = mock_optimizer
+            mock_scheduler = MagicMock()
+            mock_sched.return_value = mock_scheduler
+            
+            # Setup model
+            model = setup_model(
+                model_name_or_path="test/model",
+                use_liger_kernels=False,
+                osft=False,
+                rank=0
+            )
+            
+            # Setup training components
+            model, optimizer, scheduler = setup_training_components(
+                model,
+                learning_rate=1e-5,
+                num_warmup_steps=10,
+                lr_scheduler="constant"
+            )
+            
+            assert model is not None
+            assert optimizer is not None
+            assert scheduler is not None
 
 
 if __name__ == "__main__":

--- a/tests/test_osft.py
+++ b/tests/test_osft.py
@@ -762,9 +762,10 @@ class TestSetupModelIntegration:
     @patch('mini_trainer.setup_model_for_training.log_rank_0')
     @patch('mini_trainer.setup_model_for_training.AutoModelForCausalLM')
     @patch('mini_trainer.setup_model_for_training.AutoTokenizer')
+    @patch('mini_trainer.setup_model_for_training.AutoConfig')
     @patch('mini_trainer.osft_utils.auto_generate_target_osft_config')
     @patch('mini_trainer.osft_utils.create_osft_model_class')
-    def test_osft_params_flow_through_setup(self, mock_osft_class, mock_auto_config, mock_tokenizer_cls, mock_model_cls, mock_log):
+    def test_osft_params_flow_through_setup(self, mock_osft_class, mock_auto_config, mock_transformers_auto_config, mock_tokenizer_cls, mock_model_cls, mock_log):
         """Test that OSFT parameters flow through the setup correctly."""
         # Test that OSFT model creation gets the right parameters
         mock_auto_config.return_value = {"layer.weight": 10}

--- a/tests/test_osft_dtype_functionality.py
+++ b/tests/test_osft_dtype_functionality.py
@@ -215,7 +215,8 @@ class TestOSFTModelDtypeIntegration:
     @patch('torch.distributed.get_rank', return_value=0)
     @patch('mini_trainer.setup_model_for_training.AutoModelForCausalLM')
     @patch('mini_trainer.setup_model_for_training.AutoTokenizer')
-    def test_setup_model_assigns_dtype_attributes(self, mock_tokenizer, mock_model_class, 
+    @patch('mini_trainer.setup_model_for_training.AutoConfig')
+    def test_setup_model_assigns_dtype_attributes(self, mock_auto_config, mock_tokenizer, mock_model_class, 
                                                  mock_get_rank, mock_is_initialized, 
                                                  mock_align, mock_create_osft):
         """Test that setup_model correctly assigns dtype attributes to OSFT model."""
@@ -258,9 +259,9 @@ class TestOSFTModelDtypeIntegration:
             model_name_or_path="test-model",
             osft=True,
             rank=0,
-            upcast_dtype=torch.float32,
-            output_dtype=torch.bfloat16,
-            osft_unfreeze_rank_ratio=0.5
+            osft_upcast_dtype=torch.float32,
+            osft_output_dtype=torch.bfloat16,
+            osft_rank_ratio=0.5
         )
         
         # Verify the attributes were set correctly on the returned model

--- a/tests/test_training_components.py
+++ b/tests/test_training_components.py
@@ -233,6 +233,7 @@ class TestSaveModel:
         model.module = MagicMock()
         model.module.config = MagicMock()
         model.module.config.to_json_file = MagicMock()
+        model.module.config.torch_dtype = torch.bfloat16  # Set a proper dtype instead of MagicMock
         model.module.prepare_state_dict_for_save = MagicMock(side_effect=lambda x: x)
         return model
     
@@ -354,7 +355,7 @@ class TestSaveModel:
                 mock_fsdp_model,
                 samples_seen=1000,
                 output_dir=temp_dir,
-                model_name_or_path="test/model"
+                model_name_or_path="test/model",
             )
         
         # Should save multiple shards


### PR DESCRIPTION
This PR updates the model checkpointing logic so that the state dict gets offloaded to the CPU when saving, preventing OOM errors. 

The downside here is that we now reconstruct the model weights on the CPU during OSFT which can take around 5 mins. 
