### PR TITLE
bumps numpy to version <2.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "typer",
     "aiofiles",
     "deprecated",
-    "numpy<2",
+    "numpy<2.3",
     "datasets",
     "transformers>=4.55.0",
     "ninja",


### PR DESCRIPTION
This PR increases the numpy max version to be below 2.3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded NumPy compatibility to include versions up to 2.2.x, improving installation flexibility across modern environments.
  * Users on systems defaulting to NumPy 2.x can now install without downgrading, reducing setup friction and CI failures.
  * No feature or behavior changes; this update only affects dependency compatibility during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->