### PR TITLE
validation loss - remove epoch setting on sampler

### DIFF
--- a/src/mini_trainer/train.py
+++ b/src/mini_trainer/train.py
@@ -266,7 +266,6 @@ def compute_validation_loss(model, val_data_loader, device):
     total_batches = len(val_data_loader)
     
     with torch.no_grad():
-        val_data_loader.sampler.set_epoch(0)  # Use epoch 0 for validation
         val_data_loader_it = iter(val_data_loader)
         
         # Create progress bar only on rank 0


### PR DESCRIPTION
This PR removes a line which tried to set the epoch on the `SequentialSampler` used by the validation loss function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation data handling in distributed training by aligning sampling with the current epoch, enhancing consistency and reproducibility across epochs.
  - Prevents unintended resets of the validation sampler state, reducing repeated data ordering during validation runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->