### PR TITLE
Adds mamba convolution kernels

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -26,18 +26,21 @@ jobs:
     
     - name: Install dependencies with uv
       run: |
-        uv sync
-        uv pip install tox tox-uv
+        uv venv
+        source .venv/bin/activate
+        uv pip install -e ".[dev]"
     
     - name: Display Python and package information
       run: |
+        source .venv/bin/activate
         python --version
-        uv run tox --version
+        tox --version
         which python
     
     - name: Run Python 3.12 non-GPU tests
       run: |
-        uv run tox -e py312-nogpu-cov
+        source .venv/bin/activate
+        tox -e py312-nogpu-cov
 
   test-py311:
     name: Python 3.11 Tests
@@ -60,20 +63,23 @@ jobs:
     
     - name: Install dependencies with uv
       run: |
-        uv sync
-        uv pip install tox tox-uv
+        uv venv
+        source .venv/bin/activate
+        uv pip install -e ".[dev]"
     
     - name: Display Python and package information
       run: |
+        source .venv/bin/activate
         python --version
-        uv run tox --version
+        tox --version
         which python
     
     - name: Run Python 3.11 non-GPU tests
       run: |
-        # we will still be able to print out the coverage in this run, it just 
+        source .venv/bin/activate
+        # we will still be able to print out the coverage in this run, it just
         # won't be able to upload it to codecov
-        uv run tox -e py311-nogpu-cov
+        tox -e py311-nogpu-cov
 
   test-coverage:
     name: Test with Coverage
@@ -96,18 +102,21 @@ jobs:
     
     - name: Install dependencies with uv
       run: |
-        uv sync
-        uv pip install tox tox-uv
+        uv venv
+        source .venv/bin/activate
+        uv pip install -e ".[dev]"
     
     - name: Display Python and package information
       run: |
+        source .venv/bin/activate
         python --version
-        uv run tox --version
+        tox --version
         which python
     
     - name: Run tests with coverage
       run: |
-        uv run tox -e py312-nogpu-cov
+        source .venv/bin/activate
+        tox -e py312-nogpu-cov
     
     - name: Upload coverage results to Codecov
       uses: codecov/codecov-action@v5
@@ -139,12 +148,14 @@ jobs:
     
     - name: Install dependencies with uv
       run: |
-        uv sync
-        uv pip install tox tox-uv
+        uv venv
+        source .venv/bin/activate
+        uv pip install -e ".[dev]"
     
     - name: Check code formatting
       run: |
-        uv run tox -e format-check
+        source .venv/bin/activate
+        tox -e format-check
 
   lint:
     name: Linting (Non-blocking)
@@ -168,12 +179,14 @@ jobs:
     
     - name: Install dependencies with uv
       run: |
-        uv sync
-        uv pip install tox tox-uv
+        uv venv
+        source .venv/bin/activate
+        uv pip install -e ".[dev]"
     
     - name: Run linting checks
       run: |
-        uv run tox -e lint
+        source .venv/bin/activate
+        tox -e lint
 
   # Summary job to ensure required tests pass
   tests-passed:

--- a/Readme.md
+++ b/Readme.md
@@ -231,60 +231,71 @@ The project uses tox with uv for fast, isolated testing across multiple Python v
 
 ## Quick Testing
 
+First set up your environment:
+```shell
+# Create environment and install with dev dependencies
+uv venv --python=3.12
+source .venv/bin/activate
+uv pip install -e ".[dev]"
+```
+
+**Note**: We use direct `tox` commands instead of `uv run tox` to avoid dependency resolution issues with CUDA packages in nogpu test environments.
+
+Then run tests:
 ```shell
 # Run all tests
-uv run tox -e test
+tox -e test
 
 # Run tests with verbose output
-uv run tox -e test-verbose
+tox -e test-verbose
 
 # Run until first failure (fast feedback)
-uv run tox -e test-quick
+tox -e test-quick
 
 # Run with coverage report
-uv run tox -e test-coverage
+tox -e test-coverage
 ```
 
 ## Multi-Python Testing
 
 ```shell
 # Test on Python 3.11
-uv run tox -e py311
+tox -e py311
 
-# Test on Python 3.12  
-uv run tox -e py312
+# Test on Python 3.12
+tox -e py312
 
 # Test on all supported Python versions
-uv run tox
+tox
 ```
 
 ## Code Quality
 
 ```shell
 # Check code style with ruff
-uv run tox -e lint
+tox -e lint
 
 # Fix linting issues automatically
-uv run tox -e lint-fix
+tox -e lint-fix
 
 # Format code
-uv run tox -e format
+tox -e format
 
 # Check if code is formatted
-uv run tox -e format-check
+tox -e format-check
 ```
 
 ## Running Specific Tests
 
 ```shell
 # Run specific test file
-uv run tox -e test -- tests/test_batch_lengths_to_minibatches.py
+tox -e test -- tests/test_batch_lengths_to_minibatches.py
 
 # Run specific test class
-uv run tox -e test -- tests/test_batch_lengths_to_minibatches.py::TestBatchLengthsToMinibatches
+tox -e test -- tests/test_batch_lengths_to_minibatches.py::TestBatchLengthsToMinibatches
 
 # Run specific test method
-uv run tox -e test-quick -- tests/test_batch_lengths_to_minibatches.py::TestBatchLengthsToMinibatches::test_empty_batch
+tox -e test-quick -- tests/test_batch_lengths_to_minibatches.py::TestBatchLengthsToMinibatches::test_empty_batch
 ```
 
 ## Legacy Test Runner

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ cuda = [
     "flash-attn>=2.8.2",
     "liger-kernel>=0.5.10",  
     "kernels",  # for flash-attention-3
-    "mamba-ssm[causal-conv1d]"
+    "mamba-ssm[causal-conv1d]>=2.2.5"
 ]
 test = [
     "pytest>=7.0",

--- a/tox.ini
+++ b/tox.ini
@@ -20,13 +20,16 @@ runner = uv-venv-runner
 uv_seed = true
 
 # Base dependencies - always needed
-deps = 
+deps =
     pytest
     pytest-cov
     pytest-mock
     # GPU environments need torch and ninja
     gpu: torch>=2.6,<2.8
     gpu: ninja
+
+# Skip automatic package installation - we'll do it manually
+skip_install = true
 
 # Environment variables
 setenv = 
@@ -41,7 +44,12 @@ passenv =
     gpu: NCCL_DEBUG
 
 # Pre-commands for setup
-commands_pre = 
+commands_pre =
+    # Install package with appropriate extras for each environment
+    gpu: uv pip install -e .[cuda,test]
+    nogpu: uv pip install -e .[test]
+    !gpu-!nogpu: uv pip install -e .[test]
+
     # GPU tests: Install flash-attn in strict mode
     gpu: python -c "import sys; sys.exit(0) if __import__('importlib.util').util.find_spec('flash_attn') else None"
     gpu: python tests/gpu_tests/setup_flash_attn.py --strict


### PR DESCRIPTION
The Mamba architecture requires specialized kernels that leverage specific features of NVIDIA and AMD GPUs. This PR adds the following dependencies into our CUDA requirements installation:

```bash
In [4]: !uv pip install --dry-run mamba-ssm[causal-conv1d] --no-build-isolation
Resolved 44 packages in 16ms
Would download 2 packages
Would install 2 packages
 + causal-conv1d==1.5.2
 + mamba-ssm==2.2.5
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Simplified local testing setup with clear venv instructions and direct tox commands across sections.

- Build
  - Expanded core dependencies for smoother installs.
  - Added optional CUDA dependency to enhance GPU support.

- Tests
  - Improved tox environments: explicit install flow per GPU/non-GPU, with conditional CUDA/flash-attn setup for more reliable runs.

- Chores
  - CI now uses a dedicated virtual environment across steps for consistent tooling and test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->