### PR TITLE
Remove numpy version cap and move test dependencies to dev

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "datasets",
     "transformers>=4.55.0",
     "ninja",
-    "numba",
+    "numba>=0.62.0",
     "rich",
 ]
 


### PR DESCRIPTION
To align with numba no longer restricting the maximum numpy version, this PR removes the ceiling on numpy that can be used for this package. 

Additionally, this PR moves the `tox` and `tox-uv` packages to now be optional dependencies that are installed through `[dev]` rather than always being installed by default. `pytest` is removed from the default dependency list altogether, since it's already specified with a version restriction under the `[test]` install target. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Relaxed strict version constraints for core numerical dependency to improve compatibility.
  * Applied a minimum version requirement for a performance-related package to ensure stability.
  * Moved testing and tooling packages to development-only dependencies to streamline end-user installations.
  * No runtime behavior or user-facing functionality changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->