### PR TITLE
Pin transformers version to <5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "deprecated",
     "numpy",
     "datasets",
-    "transformers>=4.55.0",
+    "transformers>=4.55.0,<5",
     "ninja",
     "numba>=0.62.0",
     "rich",


### PR DESCRIPTION
## Summary
- Constrains the transformers dependency to versions `>=4.55.0,<5`
- Prevents potential breaking changes from major version updates

## Test plan
- [ ] Verify the package installs correctly with the new constraint
- [ ] Run existing tests to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency constraint to maintain compatibility with stable library versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->