### PR TITLE
Add backwards compatibility for transformers v4.57

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "deprecated",
     "numpy",
     "datasets",
-    "transformers>=5.0.0",
+    "transformers>=4.57.0",
     "ninja",
     "numba>=0.62.0",
     "rich",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "deprecated",
     "numpy",
     "datasets",
-    "transformers>=4.57.0",
+    "transformers>=4.57.1",
     "ninja",
     "numba>=0.62.0",
     "rich",

--- a/research_scratch/fsdp1_dummy_script.py
+++ b/research_scratch/fsdp1_dummy_script.py
@@ -53,7 +53,7 @@ def wrap_model_with_fsdp1(model: torch.nn.Module) -> FSDP:
     # Get transformer layer class for auto-wrap
     auto_wrap_policy = None
     if hasattr(model, "_no_split_modules") and model._no_split_modules:
-        layer_name = model._no_split_modules[0]
+        layer_name = next(iter(model._no_split_modules))
         layer_cls = get_module_class_from_name(model, layer_name)
         if layer_cls:
             auto_wrap_policy = functools.partial(transformer_auto_wrap_policy, transformer_layer_cls={layer_cls})

--- a/research_scratch/fsdp1_wrapper.py
+++ b/research_scratch/fsdp1_wrapper.py
@@ -38,6 +38,8 @@ def wrap_fsdp1(model: torch.nn.Module) -> torch.nn.Module:
     model.gradient_checkpointing_enable()
 
     # Determine the block class to auto-wrap (first no-split module)
+    if not model._no_split_modules:
+        raise ValueError("model._no_split_modules is empty; cannot determine FSDP block class")
     block_name = next(iter(model._no_split_modules))
     block_cls = get_module_class_from_name(model, block_name)
     if block_cls is None:

--- a/research_scratch/fsdp1_wrapper.py
+++ b/research_scratch/fsdp1_wrapper.py
@@ -38,7 +38,7 @@ def wrap_fsdp1(model: torch.nn.Module) -> torch.nn.Module:
     model.gradient_checkpointing_enable()
 
     # Determine the block class to auto-wrap (first no-split module)
-    block_name = model._no_split_modules[0]
+    block_name = next(iter(model._no_split_modules))
     block_cls = get_module_class_from_name(model, block_name)
     if block_cls is None:
         raise ValueError(f"Could not find module class named {block_name}")

--- a/scripts/process_data.py
+++ b/scripts/process_data.py
@@ -1,9 +1,14 @@
 from pathlib import Path
 
 import numpy as np
+import transformers
 import typer
 from datasets import load_dataset
 from transformers import AutoTokenizer
+
+# Transformers v5 renamed 'additional_special_tokens' to 'extra_special_tokens'
+_TRANSFORMERS_V5 = int(transformers.__version__.split(".")[0]) >= 5
+_SPECIAL_TOKENS_KEY = "extra_special_tokens" if _TRANSFORMERS_V5 else "additional_special_tokens"
 
 app = typer.Typer()
 
@@ -235,7 +240,7 @@ def process_data(
 ):
     tokenizer = AutoTokenizer.from_pretrained(model_name_or_path)
     assistant_tk_ids, user_tk_ids = infer_special_token_sequences(tokenizer)
-    tokenizer.add_special_tokens({"extra_special_tokens": [string_for_printing_masks]})
+    tokenizer.add_special_tokens({_SPECIAL_TOKENS_KEY: [string_for_printing_masks]})
     string_for_printing_masks_tk = tokenizer.encode(string_for_printing_masks, add_special_tokens=False)[0]
 
     dataset = load_dataset("json", data_files=input_jsonl, split="train")


### PR DESCRIPTION
The v5 compatibility changes pinned transformers>=5.0.0, but the LoRA path in training_hub still requires v4.57 via unsloth.

  This PR ensures both v4.57 and v5+ work:
  - Adds version-conditional key for extra_special_tokens vs additional_special_tokens in scripts/process_data.py
  - Lowers the version floor in pyproject.toml from >=5.0.0 to >=4.57.0
  - Fixes _no_split_modules[0] subscript in research_scratch/ to use next(iter(...)), which works with both v4 lists and v5 sets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Broadened Transformers compatibility to allow versions >= 4.57.1 (previously required >= 5.0.0).

* **Bug Fixes**
  * Improved robustness of internal module selection logic to handle more iterable types.
  * Added version-aware handling for special tokens so token configuration works across Transformers v4.x and v5+.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->