### PR TITLE
Replace Gram matrix V projection with factored form

### DIFF
--- a/benchmarks/bench_v_proj.py
+++ b/benchmarks/bench_v_proj.py
@@ -19,7 +19,7 @@ import torch.distributed as dist
 import torch.multiprocessing as mp
 
 
-def bench_target(name, k_high, k_low, M, P, dev, n_iters=100):
+def bench_target(name, k_high, k_low, M, P, rank, dev, n_iters=100):
     """Benchmark one OSFT target shape.  Returns dict of timings."""
     if k_high % P != 0 or k_low % P != 0:
         raise ValueError(f"k_high={k_high} and k_low={k_low} must both be divisible by P={P}")
@@ -107,13 +107,7 @@ def bench_target(name, k_high, k_low, M, P, dev, n_iters=100):
     }
 
 
-# Global for shard indexing
-rank = 0
-
-
-def run(rank_, world_size):
-    global rank
-    rank = rank_
+def run(rank, world_size):
     os.environ.update(MASTER_ADDR="localhost", MASTER_PORT="29500", RANK=str(rank), WORLD_SIZE=str(world_size))
     dist.init_process_group("nccl")
     torch.cuda.set_device(rank)
@@ -129,7 +123,7 @@ def run(rank_, world_size):
 
     results = []
     for name, k_high, k_low, M in targets:
-        r = bench_target(name, k_high, k_low, M, world_size, dev)
+        r = bench_target(name, k_high, k_low, M, world_size, rank, dev)
         results.append(r)
 
     if rank == 0:

--- a/benchmarks/bench_v_proj.py
+++ b/benchmarks/bench_v_proj.py
@@ -21,17 +21,17 @@ import torch.multiprocessing as mp
 
 def bench_target(name, k_high, k_low, M, P, dev, n_iters=100):
     """Benchmark one OSFT target shape.  Returns dict of timings."""
+    if k_high % P != 0 or k_low % P != 0:
+        raise ValueError(f"k_high={k_high} and k_low={k_low} must both be divisible by P={P}")
     local_k_high = k_high // P
     local_k_low = k_low // P
 
     # V_high has orthonormal rows (from SVD) — create via QR in float32
-    V_full_f32 = torch.linalg.qr(
-        torch.randn(M, k_high, device=dev)
-    )[0].T[:k_high]  # (k_high, M) orthonormal rows
+    V_full_f32 = torch.linalg.qr(torch.randn(M, k_high, device=dev))[0].T[:k_high]  # (k_high, M) orthonormal rows
     V_full = V_full_f32.to(torch.bfloat16)
 
     # Each rank's shard of V_high
-    local_V = V_full[rank * local_k_high:(rank + 1) * local_k_high].contiguous()
+    local_V = V_full[rank * local_k_high : (rank + 1) * local_k_high].contiguous()
     local_dV = torch.randn(local_k_low, M, device=dev, dtype=torch.bfloat16)
     dV_save = local_dV.clone()
 
@@ -95,9 +95,14 @@ def bench_target(name, k_high, k_low, M, P, dev, n_iters=100):
     max_diff = (fact_f32 - gram_f32).abs().max().item()
 
     return {
-        "name": name, "k_high": k_high, "M": M,
-        "gram_bytes": M * M * 2, "fact_bytes": k_high * M * 2,
-        "gram_ms": gram_ms, "fact_ms": fact_ms, "cached_ms": cached_ms,
+        "name": name,
+        "k_high": k_high,
+        "M": M,
+        "gram_bytes": M * M * 2,
+        "fact_bytes": k_high * M * 2,
+        "gram_ms": gram_ms,
+        "fact_ms": fact_ms,
+        "cached_ms": cached_ms,
         "max_diff": max_diff,
     }
 
@@ -109,8 +114,7 @@ rank = 0
 def run(rank_, world_size):
     global rank
     rank = rank_
-    os.environ.update(MASTER_ADDR="localhost", MASTER_PORT="29500",
-                      RANK=str(rank), WORLD_SIZE=str(world_size))
+    os.environ.update(MASTER_ADDR="localhost", MASTER_PORT="29500", RANK=str(rank), WORLD_SIZE=str(world_size))
     dist.init_process_group("nccl")
     torch.cuda.set_device(rank)
     torch.manual_seed(42)
@@ -119,8 +123,8 @@ def run(rank_, world_size):
     # Llama-8B shapes, URR=0.5
     targets = [
         # name,       k_high, k_low, M
-        ("down_proj",  2048,   2048,  14336),  # (4096, 14336) → ratio = 7x
-        ("q_proj",     2048,   2048,  4096),   # (4096, 4096)  → ratio = 2x
+        ("down_proj", 2048, 2048, 14336),  # (4096, 14336) → ratio = 7x
+        ("q_proj", 2048, 2048, 4096),  # (4096, 4096)  → ratio = 2x
     ]
 
     results = []
@@ -135,28 +139,29 @@ def run(rank_, world_size):
         print()
         for r in results:
             ratio = r["M"] / r["k_high"]
-            print(f"  {r['name']:10s}  V_high ({r['k_high']}, {r['M']})"
-                  f"    M/k_high = {ratio:.0f}x")
+            print(f"  {r['name']:10s}  V_high ({r['k_high']}, {r['M']})    M/k_high = {ratio:.0f}x")
             print(f"  {'':10s}  Gram        Factored    Cached")
             print(f"  {'':10s}  ----------  ----------  ----------")
             print(f"  {'comm':10s}  all-reduce  all-gather  none")
-            print(f"  {'bytes':10s}  {r['gram_bytes']/1e6:>7.0f} MB  {r['fact_bytes']/1e6:>7.0f} MB  {0:>7.0f} MB")
+            print(f"  {'bytes':10s}  {r['gram_bytes'] / 1e6:>7.0f} MB  {r['fact_bytes'] / 1e6:>7.0f} MB  {0:>7.0f} MB")
             print(f"  {'time':10s}  {r['gram_ms']:>7.2f} ms  {r['fact_ms']:>7.2f} ms  {r['cached_ms']:>7.2f} ms")
-            print(f"  {'speedup':10s}  {'—':>10s}  {r['gram_ms']/r['fact_ms']:>7.1f}x    {r['gram_ms']/r['cached_ms']:>7.1f}x")
+            print(
+                f"  {'speedup':10s}  {'—':>10s}  {r['gram_ms'] / r['fact_ms']:>7.1f}x    {r['gram_ms'] / r['cached_ms']:>7.1f}x"
+            )
             ok = "ok" if r["max_diff"] < 1e-4 else "FAIL"
             print(f"  {'correct':10s}  —           f32 max diff = {r['max_diff']:.1e} ({ok})")
             print()
 
-        # Aggregate: 32 layers × 7 targets (4 q/k/v/o + 2 gate/up + 1 down)
+        # Aggregate: 32 layers x 7 targets (4 q/k/v/o + 2 gate/up + 1 down)
         sq = next(r for r in results if r["name"] == "q_proj")
         dp = next(r for r in results if r["name"] == "down_proj")
         gram_tot = (6 * sq["gram_ms"] + dp["gram_ms"]) * 32
         fact_tot = (6 * sq["fact_ms"] + dp["fact_ms"]) * 32
         cached_tot = (6 * sq["cached_ms"] + dp["cached_ms"]) * 32
-        print(f"  Aggregate (32 layers × 7 targets = 224):")
+        print("  Aggregate (32 layers x 7 targets = 224):")
         print(f"  {'':10s}  Gram        Factored    Cached")
         print(f"  {'total':10s}  {gram_tot:>7.0f} ms  {fact_tot:>7.0f} ms  {cached_tot:>7.0f} ms")
-        print(f"  {'speedup':10s}  {'—':>10s}  {gram_tot/fact_tot:>7.1f}x    {gram_tot/cached_tot:>7.1f}x")
+        print(f"  {'speedup':10s}  {'—':>10s}  {gram_tot / fact_tot:>7.1f}x    {gram_tot / cached_tot:>7.1f}x")
         print()
 
     dist.destroy_process_group()

--- a/benchmarks/bench_v_proj.py
+++ b/benchmarks/bench_v_proj.py
@@ -1,0 +1,166 @@
+"""Benchmark: Gram vs factored V projection under FSDP2-style sharding.
+
+Measures the V projection step of project_gradient_to_orthogonal_space()
+with Llama-8B shapes.  Compares three modes:
+
+  Gram:     all-reduce (M, M) Gram matrix, then dV -= dV @ G
+  Factored: all-gather (k_high, M) V_high, then dV -= (dV @ V^T) @ V
+  Cached:   reuse V_high from prior step (no comm), same matmuls
+
+Usage:
+  python bench_v_proj.py           # requires 2 GPUs
+"""
+
+import os
+import time
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+
+def bench_target(name, k_high, k_low, M, P, dev, n_iters=100):
+    """Benchmark one OSFT target shape.  Returns dict of timings."""
+    local_k_high = k_high // P
+    local_k_low = k_low // P
+
+    # V_high has orthonormal rows (from SVD) — create via QR in float32
+    V_full_f32 = torch.linalg.qr(
+        torch.randn(M, k_high, device=dev)
+    )[0].T[:k_high]  # (k_high, M) orthonormal rows
+    V_full = V_full_f32.to(torch.bfloat16)
+
+    # Each rank's shard of V_high
+    local_V = V_full[rank * local_k_high:(rank + 1) * local_k_high].contiguous()
+    local_dV = torch.randn(local_k_low, M, device=dev, dtype=torch.bfloat16)
+    dV_save = local_dV.clone()
+
+    # Pre-allocate for all-gather
+    V_ag = torch.empty_like(V_full)
+
+    # Warmup
+    for _ in range(10):
+        local_dV.copy_(dV_save)
+        G = torch.mm(local_V.T, local_V)
+        dist.all_reduce(G)
+        local_dV.add_(torch.mm(local_dV, G), alpha=-1.0)
+
+        local_dV.copy_(dV_save)
+        dist.all_gather_into_tensor(V_ag, local_V)
+        coeff = torch.mm(local_dV, V_ag.T)
+        local_dV.addmm_(coeff, V_ag, alpha=-1.0)
+    torch.cuda.synchronize()
+    dist.barrier()
+
+    # --- Gram form: all-reduce (M, M), then dV -= dV @ G ---
+    torch.cuda.synchronize()
+    dist.barrier()
+    t0 = time.perf_counter()
+    for _ in range(n_iters):
+        local_dV.copy_(dV_save)
+        G = torch.mm(local_V.T, local_V)
+        dist.all_reduce(G)
+        local_dV.add_(torch.mm(local_dV, G), alpha=-1.0)
+    torch.cuda.synchronize()
+    gram_ms = (time.perf_counter() - t0) / n_iters * 1000
+
+    # --- Factored form: all-gather (k_high, M), then two matmuls ---
+    torch.cuda.synchronize()
+    dist.barrier()
+    t0 = time.perf_counter()
+    for _ in range(n_iters):
+        local_dV.copy_(dV_save)
+        dist.all_gather_into_tensor(V_ag, local_V)
+        coeff = torch.mm(local_dV, V_ag.T)
+        local_dV.addmm_(coeff, V_ag, alpha=-1.0)
+    torch.cuda.synchronize()
+    fact_ms = (time.perf_counter() - t0) / n_iters * 1000
+
+    # --- Cached: no comm, just matmuls ---
+    torch.cuda.synchronize()
+    dist.barrier()
+    t0 = time.perf_counter()
+    for _ in range(n_iters):
+        local_dV.copy_(dV_save)
+        coeff = torch.mm(local_dV, V_ag.T)
+        local_dV.addmm_(coeff, V_ag, alpha=-1.0)
+    torch.cuda.synchronize()
+    cached_ms = (time.perf_counter() - t0) / n_iters * 1000
+
+    # Correctness: verify in float32 (bf16 accumulation differs by ~5%)
+    dV_f32 = dV_save.float()
+    V_f32 = V_full_f32
+    gram_f32 = dV_f32 - dV_f32 @ (V_f32.T @ V_f32)
+    fact_f32 = dV_f32 - (dV_f32 @ V_f32.T) @ V_f32
+    max_diff = (fact_f32 - gram_f32).abs().max().item()
+
+    return {
+        "name": name, "k_high": k_high, "M": M,
+        "gram_bytes": M * M * 2, "fact_bytes": k_high * M * 2,
+        "gram_ms": gram_ms, "fact_ms": fact_ms, "cached_ms": cached_ms,
+        "max_diff": max_diff,
+    }
+
+
+# Global for shard indexing
+rank = 0
+
+
+def run(rank_, world_size):
+    global rank
+    rank = rank_
+    os.environ.update(MASTER_ADDR="localhost", MASTER_PORT="29500",
+                      RANK=str(rank), WORLD_SIZE=str(world_size))
+    dist.init_process_group("nccl")
+    torch.cuda.set_device(rank)
+    torch.manual_seed(42)
+    dev = f"cuda:{rank}"
+
+    # Llama-8B shapes, URR=0.5
+    targets = [
+        # name,       k_high, k_low, M
+        ("down_proj",  2048,   2048,  14336),  # (4096, 14336) → ratio = 7x
+        ("q_proj",     2048,   2048,  4096),   # (4096, 4096)  → ratio = 2x
+    ]
+
+    results = []
+    for name, k_high, k_low, M in targets:
+        r = bench_target(name, k_high, k_low, M, world_size, dev)
+        results.append(r)
+
+    if rank == 0:
+        gpu = torch.cuda.get_device_name(0)
+        print(f"V projection benchmark — {world_size}× {gpu}, Llama-8B shapes, bf16")
+        print("=" * 70)
+        print()
+        for r in results:
+            ratio = r["M"] / r["k_high"]
+            print(f"  {r['name']:10s}  V_high ({r['k_high']}, {r['M']})"
+                  f"    M/k_high = {ratio:.0f}x")
+            print(f"  {'':10s}  Gram        Factored    Cached")
+            print(f"  {'':10s}  ----------  ----------  ----------")
+            print(f"  {'comm':10s}  all-reduce  all-gather  none")
+            print(f"  {'bytes':10s}  {r['gram_bytes']/1e6:>7.0f} MB  {r['fact_bytes']/1e6:>7.0f} MB  {0:>7.0f} MB")
+            print(f"  {'time':10s}  {r['gram_ms']:>7.2f} ms  {r['fact_ms']:>7.2f} ms  {r['cached_ms']:>7.2f} ms")
+            print(f"  {'speedup':10s}  {'—':>10s}  {r['gram_ms']/r['fact_ms']:>7.1f}x    {r['gram_ms']/r['cached_ms']:>7.1f}x")
+            ok = "ok" if r["max_diff"] < 1e-4 else "FAIL"
+            print(f"  {'correct':10s}  —           f32 max diff = {r['max_diff']:.1e} ({ok})")
+            print()
+
+        # Aggregate: 32 layers × 7 targets (4 q/k/v/o + 2 gate/up + 1 down)
+        sq = next(r for r in results if r["name"] == "q_proj")
+        dp = next(r for r in results if r["name"] == "down_proj")
+        gram_tot = (6 * sq["gram_ms"] + dp["gram_ms"]) * 32
+        fact_tot = (6 * sq["fact_ms"] + dp["fact_ms"]) * 32
+        cached_tot = (6 * sq["cached_ms"] + dp["cached_ms"]) * 32
+        print(f"  Aggregate (32 layers × 7 targets = 224):")
+        print(f"  {'':10s}  Gram        Factored    Cached")
+        print(f"  {'total':10s}  {gram_tot:>7.0f} ms  {fact_tot:>7.0f} ms  {cached_tot:>7.0f} ms")
+        print(f"  {'speedup':10s}  {'—':>10s}  {gram_tot/fact_tot:>7.1f}x    {gram_tot/cached_tot:>7.1f}x")
+        print()
+
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    mp.spawn(run, args=(2,), nprocs=2, join=True)

--- a/src/mini_trainer/osft_utils.py
+++ b/src/mini_trainer/osft_utils.py
@@ -630,10 +630,9 @@ def project_gradient_to_orthogonal_space(
                         dist.all_gather_into_tensor(V_high_full, local_V_high)
                     else:
                         # Uneven split — DTensor Shard(0) uses torch.chunk
-                        # semantics: all shards have ceil(k/P) rows except
-                        # the last which gets the remainder.  Pad each shard
-                        # to ceil rows for all_gather_into_tensor, then
-                        # extract valid rows per rank.
+                        # semantics: only the last shard is short, so padding
+                        # lands at the tail of the gathered buffer.  Pad to
+                        # ceil rows for all_gather, then slice off padding.
                         rows_per_rank = math.ceil(full_k_high / world_size)
                         padded = torch.zeros(
                             rows_per_rank,
@@ -649,11 +648,7 @@ def project_gradient_to_orthogonal_space(
                             device=local_V_high.device,
                         )
                         dist.all_gather_into_tensor(gathered, padded)
-                        parts = []
-                        for i in range(world_size):
-                            n = min(rows_per_rank, full_k_high - rows_per_rank * i)
-                            parts.append(gathered[i * rows_per_rank : i * rows_per_rank + n])
-                        V_high_full = torch.cat(parts)
+                        V_high_full = gathered[:full_k_high]
                 else:
                     # to_local() returned the full tensor (not FSDP-sharded)
                     V_high_full = local_V_high

--- a/src/mini_trainer/osft_utils.py
+++ b/src/mini_trainer/osft_utils.py
@@ -24,6 +24,20 @@ OSFT_CACHE_CLEAR_INTERVAL = int(
     os.getenv("OSFT_CACHE_CLEAR_INTERVAL", 5)
 )  # Clear GPU cache every N parameters during matrix reconstruction
 
+# Opt-in: cache the all-gathered (full) V_high to avoid repeating the
+# all-gather on every step.  V_high is frozen (requires_grad=False), so the
+# cache is exact.
+#
+# V projection uses the factored form: dV -= (dV @ V_high^T) @ V_high.
+# Under FSDP2, V_high is dim-0 sharded, so the factored form requires an
+# all-gather of V_high (k_high × M).  Caching stores the all-gathered result.
+#
+# Default OFF because the cache is REPLICATED on every FSDP2 rank (not
+# sharded), adding ~5.1 GB per rank for Llama-8B (all 224 targets in bf16).
+# For Llama-70B+ the cache exceeds GPU memory.  Set to "1" only after
+# confirming sufficient memory headroom.
+OSFT_CACHE_V = os.getenv("OSFT_CACHE_V", "0") == "1"
+
 
 def _supports_use_batch() -> bool:
     """Check if torch.distributed send/recv_object_list support the use_batch parameter (PyTorch 2.9+)."""
@@ -520,33 +534,38 @@ def reconstruct_weight_matrix(
     return reconstructed
 
 
-def project_gradient_to_orthogonal_space(svd_dict: SVDDecompositionDict, *, skip_u: bool = False):
+def project_gradient_to_orthogonal_space(
+    svd_dict: SVDDecompositionDict,
+    *,
+    skip_u: bool = False,
+    cache_holder: "nn.Module | None" = None,
+):
     """
     Projects the gradient of the low-rank parameters (U_low, V_low) to be
     orthogonal to the frozen high-rank subspace.
 
-    Implements the orthogonal gradient projection from Nayak et al.,
-    "Sculpting Subspaces: Constrained Full Fine-Tuning in LLMs for Continual
-    Learning" (arXiv:2504.07097, Eq. 4, Theorem 1).  The projection ensures
-    that weight updates lie in the orthogonal complement of the frozen singular
-    subspace, bounding catastrophic forgetting via the Hierarchy of Forgetting
-    Bounds (Theorem 1).
+    Both projections use the factored form:
+      dU -= U_high @ (U_high^T @ dU)
+      dV -= (dV @ V_high^T) @ V_high
 
-    U projection uses the factored form  dU -= U_high @ (U_high^T @ dU)  with
-    a small (k, k_low) intermediate — the orthogonal complement projection
-    (I - U_high @ U_high^T) dU that removes the col(U_high) component
-    (cf. Edelman, Arias & Smith 1998, arXiv:physics/9806030, §2.5.1).
+    Under FSDP2, U_high is dim-0 sharded along N (the large dimension), so
+    U_high^T @ dU contracts over the sharded dim → partial sum → all-reduce
+    of a small (k_high, k_low) matrix.
 
-    V projection must use the Gram-matrix form
-    dV -= dV @ (V_high^T @ V_high)  because FSDP2 shards V_high on dim-0
-    (the singular-vector dimension), making the factored form
-    dV -= (dV @ V_high^T) @ V_high  produce column-blocks rather than
-    partial sums — requiring an all-gather instead of an all-reduce.
+    V_high is dim-0 sharded along k_high (the small dimension), so the
+    factored form requires an all-gather of V_high to get the full
+    (k_high, M) tensor.  This is M/k_high fewer bytes than the Gram
+    matrix all-reduce (k_high × M vs M × M) — 2x for square weights,
+    7x for down_proj where k_high = min(N, M) × (1 - URR).
 
     Args:
         svd_dict: Dictionary containing the SVD decomposition components.
         skip_u: If True, skip U projection (caller handles it externally,
             e.g. via batched all-reduce in distributed mode).
+        cache_holder: Optional module on which to cache the all-gathered
+            V_high.  V_high is frozen, so the cache is exact.  When provided
+            and OSFT_CACHE_V is enabled, V_high is all-gathered once and
+            reused on subsequent steps.
 
     TODO(osilkin): Add mixed-precision gradients here
     """
@@ -579,24 +598,37 @@ def project_gradient_to_orthogonal_space(svd_dict: SVDDecompositionDict, *, skip
         else:
             dU.copy_(local_dU)
 
-    # Project V_low gradients to space orthogonal to row(V_high).
-    # V_high has shape (k, M) with orthonormal rows (from SVD).
-    # G = V_high^T @ V_high is the (M, M) orthogonal projector onto row(V_high).
-    # dV -= dV @ G  removes each row's component in that subspace.
+    # Project V_low gradients: dV -= (dV @ V_high^T) @ V_high
+    # All-gather V_high from FSDP2 shards (or use cache) — see docstring for cost analysis.
     if svd_dict["V_low"].grad is not None:
         dV = svd_dict["V_low"].grad
         local_V_high = getattr(V_high, "to_local", lambda: V_high)()
         local_dV = getattr(dV, "to_local", lambda: dV)()
 
-        # Compute Gram matrix G = V_high^T @ V_high for global projection across row-sharded V_high
-        # Assumes column dimension is consistent across ranks (row sharding over singular vectors)
-        G_local = torch.mm(local_V_high.transpose(0, 1), local_V_high)
-        if dist.is_initialized() and dist.get_world_size() > 1:
-            dist.all_reduce(G_local, op=dist.ReduceOp.SUM)
+        # V_high is frozen — reuse cached all-gathered tensor when available.
+        can_cache = OSFT_CACHE_V and cache_holder is not None
+        cached = getattr(cache_holder, "_osft_v_high_full", None) if can_cache else None
 
-        # Apply projection: dV = dV - dV @ G (use local shard of dV)
-        update = torch.mm(local_dV, G_local)
-        local_dV.add_(update, alpha=-1.0)
+        if cached is not None:
+            V_high_full = cached
+        else:
+            if dist.is_initialized() and dist.get_world_size() > 1:
+                world_size = dist.get_world_size()
+                V_high_full = torch.empty(
+                    local_V_high.shape[0] * world_size, local_V_high.shape[1],
+                    dtype=local_V_high.dtype, device=local_V_high.device,
+                )
+                dist.all_gather_into_tensor(V_high_full, local_V_high)
+            else:
+                V_high_full = local_V_high
+            if can_cache:
+                # .detach() ensures plain Tensor, not nn.Parameter — avoids
+                # nn.Module.__setattr__ registering it into state_dict.
+                cache_holder._osft_v_high_full = V_high_full.detach()
+
+        # Two local matmuls — no (M, M) intermediate
+        coeff = torch.mm(local_dV, V_high_full.transpose(0, 1))  # (k_low/P, k_high)
+        local_dV.addmm_(coeff, V_high_full, alpha=-1.0)          # (k_low/P, M)
 
         if hasattr(dV, "_local_tensor"):
             dV._local_tensor.copy_(local_dV)
@@ -1022,6 +1054,10 @@ def create_osft_model_class(base_cls) -> type[OSFTModel]:
             self.osft_paramspec_registry = {}
             self._osft_handles = {}
             self.osft_params = {}
+            # Clear any cached all-gathered V_high — V_high changes on reinit.
+            for module in self.modules():
+                if hasattr(module, "_osft_v_high_full"):
+                    del module._osft_v_high_full
 
         @staticmethod
         def _load_non_distributed(
@@ -2043,6 +2079,12 @@ def create_osft_model_class(base_cls) -> type[OSFTModel]:
             all-reduce instead of one per OSFT target. For Llama-8B with 224 targets
             this reduces 224 U all-reduce kernel launches to 1, cutting latency from
             collective launch overhead. V projections continue per-module.
+
+            When ``OSFT_CACHE_V=1`` is set, the all-gathered V_high tensor is
+            cached on each module after the first step.  V_high is frozen, so
+            the cache is exact.  This eliminates per-step V all-gather traffic.
+            Default is off because the cache is replicated on every FSDP2 rank
+            (~5.1 GB for Llama-8B, infeasible for 70B+).
             """
             is_distributed = dist.is_initialized() and dist.get_world_size() > 1
 
@@ -2067,7 +2109,7 @@ def create_osft_model_class(base_cls) -> type[OSFTModel]:
                         svd_dict = self.get_svd_dict_for_module(module)
                     except ValueError as err:
                         raise ValueError(f"error in projecting gradients for module: {module}") from err
-                    project_gradient_to_orthogonal_space(svd_dict)
+                    project_gradient_to_orthogonal_space(svd_dict, cache_holder=module)
                 return
 
             # Distributed: batch U projection all-reduces.
@@ -2084,6 +2126,7 @@ def create_osft_model_class(base_cls) -> type[OSFTModel]:
             u_work = []  # (local_U_high, local_dU, dU, coeff_shape) per target
             u_flat_parts = []
             svd_dicts = []
+            svd_modules = []
 
             for module in osft_modules:
                 try:
@@ -2091,6 +2134,7 @@ def create_osft_model_class(base_cls) -> type[OSFTModel]:
                 except ValueError as err:
                     raise ValueError(f"error in projecting gradients for module: {module}") from err
                 svd_dicts.append(svd_dict)
+                svd_modules.append(module)
 
                 if svd_dict["U_low"].grad is not None:
                     dU = svd_dict["U_low"].grad
@@ -2125,12 +2169,29 @@ def create_osft_model_class(base_cls) -> type[OSFTModel]:
                     f"Batch split consumed {offset} elements but tensor has {batched.numel()}"
                 )
 
-            # V projections: per-module (Gram matrix all-reduce per target).
+            # V projections: per-module factored V all-gather.
             # Reuse the shared function with skip_u=True to avoid code
             # duplication — the V projection logic is identical to the
             # non-batched path.
-            for svd_dict in svd_dicts:
-                project_gradient_to_orthogonal_space(svd_dict, skip_u=True)
+            caches_populated_this_call = 0
+            for svd_dict, module in zip(svd_dicts, svd_modules):
+                had_cache = hasattr(module, "_osft_v_high_full")
+                project_gradient_to_orthogonal_space(svd_dict, skip_u=True, cache_holder=module)
+                if not had_cache and hasattr(module, "_osft_v_high_full"):
+                    caches_populated_this_call += 1
+
+            if caches_populated_this_call > 0:
+                total_bytes = sum(
+                    module._osft_v_high_full.nelement() * module._osft_v_high_full.element_size()
+                    for module in self.modules()
+                    if hasattr(module, "_osft_v_high_full")
+                )
+                log_rank_0(
+                    f"Cached {caches_populated_this_call} V_high tensors "
+                    f"({total_bytes / 1e9:.2f} GB). "
+                    f"Subsequent steps skip V all-gathers. "
+                    f"Set OSFT_CACHE_V=0 to disable."
+                )
 
         def prepare_state_dict_for_save(self, state_dict):
             """Reconstruct dense weights into ``state_dict`` for saving with memory optimization."""

--- a/src/mini_trainer/osft_utils.py
+++ b/src/mini_trainer/osft_utils.py
@@ -1,4 +1,5 @@
 import gc
+import math
 import os
 import types
 import typing as t
@@ -30,7 +31,7 @@ OSFT_CACHE_CLEAR_INTERVAL = int(
 #
 # V projection uses the factored form: dV -= (dV @ V_high^T) @ V_high.
 # Under FSDP2, V_high is dim-0 sharded, so the factored form requires an
-# all-gather of V_high (k_high × M).  Caching stores the all-gathered result.
+# all-gather of V_high (k_high x M).  Caching stores the all-gathered result.
 #
 # Default OFF because the cache is REPLICATED on every FSDP2 rank (not
 # sharded), adding ~5.1 GB per rank for Llama-8B (all 224 targets in bf16).
@@ -613,12 +614,49 @@ def project_gradient_to_orthogonal_space(
             V_high_full = cached
         else:
             if dist.is_initialized() and dist.get_world_size() > 1:
-                world_size = dist.get_world_size()
-                V_high_full = torch.empty(
-                    local_V_high.shape[0] * world_size, local_V_high.shape[1],
-                    dtype=local_V_high.dtype, device=local_V_high.device,
-                )
-                dist.all_gather_into_tensor(V_high_full, local_V_high)
+                full_k_high = svd_dict["rank_high"]
+                if local_V_high.shape[0] < full_k_high:
+                    # FSDP2-sharded: all-gather V_high from all ranks.
+                    world_size = dist.get_world_size()
+                    remainder = full_k_high % world_size
+                    if remainder == 0:
+                        # Even split — direct gather, no padding needed.
+                        V_high_full = torch.empty(
+                            full_k_high,
+                            local_V_high.shape[1],
+                            dtype=local_V_high.dtype,
+                            device=local_V_high.device,
+                        )
+                        dist.all_gather_into_tensor(V_high_full, local_V_high)
+                    else:
+                        # Uneven split — DTensor Shard(0) uses torch.chunk
+                        # semantics: all shards have ceil(k/P) rows except
+                        # the last which gets the remainder.  Pad each shard
+                        # to ceil rows for all_gather_into_tensor, then
+                        # extract valid rows per rank.
+                        rows_per_rank = math.ceil(full_k_high / world_size)
+                        padded = torch.zeros(
+                            rows_per_rank,
+                            local_V_high.shape[1],
+                            dtype=local_V_high.dtype,
+                            device=local_V_high.device,
+                        )
+                        padded[: local_V_high.shape[0]].copy_(local_V_high)
+                        gathered = torch.empty(
+                            rows_per_rank * world_size,
+                            local_V_high.shape[1],
+                            dtype=local_V_high.dtype,
+                            device=local_V_high.device,
+                        )
+                        dist.all_gather_into_tensor(gathered, padded)
+                        parts = []
+                        for i in range(world_size):
+                            n = min(rows_per_rank, full_k_high - rows_per_rank * i)
+                            parts.append(gathered[i * rows_per_rank : i * rows_per_rank + n])
+                        V_high_full = torch.cat(parts)
+                else:
+                    # to_local() returned the full tensor (not FSDP-sharded)
+                    V_high_full = local_V_high
             else:
                 V_high_full = local_V_high
             if can_cache:
@@ -628,7 +666,7 @@ def project_gradient_to_orthogonal_space(
 
         # Two local matmuls — no (M, M) intermediate
         coeff = torch.mm(local_dV, V_high_full.transpose(0, 1))  # (k_low/P, k_high)
-        local_dV.addmm_(coeff, V_high_full, alpha=-1.0)          # (k_low/P, M)
+        local_dV.addmm_(coeff, V_high_full, alpha=-1.0)  # (k_low/P, M)
 
         if hasattr(dV, "_local_tensor"):
             dV._local_tensor.copy_(local_dV)

--- a/tests/test_osft.py
+++ b/tests/test_osft.py
@@ -1572,6 +1572,8 @@ class TestBatchedUAllReduce:
         # No-op all_reduce: with a single real rank, the local value IS the
         # global value, so identity is correct.
         monkeypatch.setattr(dist, "all_reduce", lambda tensor, op=None: None)
+        # V projection detects that local_V_high is already the full tensor
+        # (shape[0] == rank_high) and skips all_gather, so no mock needed.
         model_bat.project_gradients()  # takes batched path
 
         # Compare every projected gradient
@@ -1681,8 +1683,8 @@ class TestVProjectionCache:
             if hasattr(module, "_osft_v_high_full") and hasattr(module, "osft_V_high"):
                 V = module._osft_v_high_full
                 M = V.shape[1]
-                cache_elements = V.nelement()         # k_high * M
-                gram_elements = M * M                  # M * M
+                cache_elements = V.nelement()  # k_high * M
+                gram_elements = M * M  # M * M
                 assert cache_elements < gram_elements, (
                     f"Cache ({cache_elements}) should be smaller than Gram ({gram_elements})"
                 )
@@ -1725,8 +1727,7 @@ class TestVProjectionCache:
         gram_result = raw_dV - raw_dV @ G
 
         assert torch.allclose(factored_result, gram_result, atol=1e-6), (
-            f"Factored and Gram projections differ: max diff = "
-            f"{(factored_result - gram_result).abs().max().item()}"
+            f"Factored and Gram projections differ: max diff = {(factored_result - gram_result).abs().max().item()}"
         )
 
     def test_factored_matches_gram_rectangular(self):
@@ -1814,8 +1815,9 @@ class TestVProjectionCache:
                     "U_low gradient differs with vs without cache"
                 )
 
-    def test_cache_disabled_by_default(self):
+    def test_cache_disabled_by_default(self, monkeypatch):
         """Cache should not be populated when OSFT_CACHE_V is at its default (off)."""
+        monkeypatch.setattr(osft_module, "OSFT_CACHE_V", False)
 
         model = self._create_simple_osft_model()
         model.train()
@@ -1908,6 +1910,235 @@ class TestVProjectionCache:
         sd = model.state_dict()
         for key in sd:
             assert "_osft_v_high_full" not in key, f"Cache leaked into state_dict: {key}"
+
+
+class TestUnevenShardDeinterleave:
+    """Test the uneven-shard de-interleave path in factored V projection.
+
+    When k_high % world_size != 0, DTensor Shard(0) uses torch.chunk
+    semantics: all shards have ceil(k_high/ws) rows except the last
+    which gets the remainder.  all_gather_into_tensor requires equal-
+    sized inputs, so each shard is padded to ceil rows.  After gathering,
+    padding zeros are interspersed (not at the tail) and must be
+    extracted per rank.
+
+    These tests mock the distributed primitives to exercise the de-interleave
+    logic from a single-process test.
+    """
+
+    @staticmethod
+    def _make_ortho_V(k_high, M):
+        """Create an orthonormal (k_high, M) matrix via QR."""
+        Q = torch.linalg.qr(torch.randn(M, k_high, dtype=torch.float64))[0]
+        return Q.T[:k_high].contiguous()  # (k_high, M)
+
+    @staticmethod
+    def _shard_dtensor_style(V_full, world_size):
+        """Split V_full (k_high, M) into per-rank shards using torch.chunk semantics.
+
+        DTensor Shard(0) uses torch.chunk: all shards have ceil(k/ws) rows
+        except the last which gets the remainder.
+        """
+        return list(torch.chunk(V_full, world_size, dim=0))
+
+    def _run_uneven_shard_test(self, k_high, world_size, monkeypatch):
+        """Run one uneven-shard test case.
+
+        Simulates rank 0's view: its local shard is chunk[0].
+        The mock all_gather fills the output buffer with all ranks' padded shards.
+        Then project_gradient_to_orthogonal_space de-interleaves and projects.
+        """
+        import math
+
+        import torch.distributed as dist
+
+        M = k_high * 3  # arbitrary, just needs M > k_high
+        k_low = max(k_high // 2, 1)
+
+        torch.manual_seed(42)
+        V_full = self._make_ortho_V(k_high, M)
+        dV_raw = torch.randn(k_low, M, dtype=torch.float64)
+
+        # Reference: non-distributed factored projection
+        coeff_ref = dV_raw @ V_full.T
+        dV_ref = dV_raw - coeff_ref @ V_full
+
+        # Shards as DTensor Shard(0) would produce
+        shards = self._shard_dtensor_style(V_full, world_size)
+        local_shard = shards[0]  # rank 0's shard
+
+        # Build mock all_gather: simulate all ranks contributing padded shards
+        rows_per_rank = math.ceil(k_high / world_size)
+
+        def mock_all_gather(output, input_tensor):
+            """Fill output with padded shards from all ranks."""
+            for i, shard in enumerate(shards):
+                padded = torch.zeros(rows_per_rank, M, dtype=V_full.dtype, device=V_full.device)
+                padded[: shard.shape[0]].copy_(shard)
+                output[i * rows_per_rank : (i + 1) * rows_per_rank].copy_(padded)
+
+        # Create a V_high tensor with to_local() returning the local shard
+        class FakeShardedTensor:
+            """Mimics a DTensor with to_local() returning the local shard."""
+
+            def __init__(self, local):
+                self._local = local
+
+            def to_local(self):
+                return self._local
+
+            # Proxy attribute access to the local tensor for anything else
+            def __getattr__(self, name):
+                return getattr(self._local, name)
+
+        fake_V_high = FakeShardedTensor(local_shard)
+
+        # Build svd_dict — only V_low grad and V_high matter for skip_u=True
+        V_low = nn.Parameter(torch.randn(k_low, M, dtype=torch.float64))
+        V_low.grad = dV_raw.clone()
+
+        svd_dict = {
+            "U_high": torch.randn(1, 1, dtype=torch.float64),  # unused with skip_u
+            "S_high": torch.randn(k_high, dtype=torch.float64),
+            "V_high": fake_V_high,
+            "U_low": nn.Parameter(torch.randn(1, 1, dtype=torch.float64)),
+            "S_low": nn.Parameter(torch.randn(1, dtype=torch.float64)),
+            "V_low": V_low,
+            "rank_high": k_high,
+        }
+
+        # Mock distributed
+        monkeypatch.setattr(dist, "is_initialized", lambda: True)
+        monkeypatch.setattr(dist, "get_world_size", lambda: world_size)
+        monkeypatch.setattr(dist, "all_gather_into_tensor", mock_all_gather)
+
+        project_gradient_to_orthogonal_space(svd_dict, skip_u=True)
+
+        projected_dV = V_low.grad
+        assert torch.allclose(projected_dV, dV_ref, atol=1e-10), (
+            f"Uneven shard de-interleave failed for k_high={k_high}, ws={world_size}: "
+            f"max |diff| = {(projected_dV - dV_ref).abs().max().item():.2e}"
+        )
+
+        # Verify orthogonality: projected gradient has no component in row(V_high)
+        overlap = projected_dV @ V_full.T
+        assert torch.allclose(overlap, torch.zeros_like(overlap), atol=1e-10), (
+            f"Projected gradient not orthogonal to V_high: max |dV @ V_high^T| = {overlap.abs().max().item():.2e}"
+        )
+
+    @pytest.mark.parametrize(
+        "k_high,world_size",
+        [
+            (7, 3),  # chunk sizes [3, 3, 1]
+            (5, 3),  # chunk sizes [2, 2, 1]
+            (10, 3),  # chunk sizes [4, 4, 2]
+            (11, 4),  # chunk sizes [3, 3, 3, 2]
+            (3, 2),  # chunk sizes [2, 1]
+        ],
+    )
+    def test_uneven_shard_cases(self, k_high, world_size, monkeypatch):
+        """Uneven shard de-interleave must recover the correct V_high."""
+        self._run_uneven_shard_test(k_high, world_size, monkeypatch)
+
+    @pytest.mark.parametrize(
+        "k_high,world_size",
+        [
+            (6, 3),  # even: shards [2, 2, 2]
+            (8, 4),  # even: shards [2, 2, 2, 2]
+            (10, 2),  # even: shards [5, 5]
+        ],
+    )
+    def test_even_shard_baseline(self, k_high, world_size, monkeypatch):
+        """Even shards (no remainder) should also work correctly."""
+        self._run_uneven_shard_test(k_high, world_size, monkeypatch)
+
+    def test_cache_stores_deinterleaved_v_high(self, monkeypatch):
+        """Cache must store the correctly de-interleaved V_high, not raw gathered buffer.
+
+        Step 1 populates the cache via the uneven all-gather path.
+        Step 2 hits the cache (no all-gather).  Both must produce the
+        same projection as the non-distributed reference.
+        """
+        import math
+
+        import torch.distributed as dist
+
+        monkeypatch.setattr(osft_module, "OSFT_CACHE_V", True)
+
+        k_high, world_size = 7, 3  # uneven: chunk sizes [3, 3, 1]
+        M = k_high * 3
+        k_low = k_high // 2
+
+        torch.manual_seed(42)
+        V_full = self._make_ortho_V(k_high, M)
+        shards = self._shard_dtensor_style(V_full, world_size)
+        local_shard = shards[0]
+        rows_per_rank = math.ceil(k_high / world_size)
+
+        gather_call_count = 0
+
+        def mock_all_gather(output, input_tensor):
+            nonlocal gather_call_count
+            gather_call_count += 1
+            for i, shard in enumerate(shards):
+                padded = torch.zeros(rows_per_rank, M, dtype=V_full.dtype, device=V_full.device)
+                padded[: shard.shape[0]].copy_(shard)
+                output[i * rows_per_rank : (i + 1) * rows_per_rank].copy_(padded)
+
+        monkeypatch.setattr(dist, "is_initialized", lambda: True)
+        monkeypatch.setattr(dist, "get_world_size", lambda: world_size)
+        monkeypatch.setattr(dist, "all_gather_into_tensor", mock_all_gather)
+
+        class FakeShardedTensor:
+            def __init__(self, local):
+                self._local = local
+
+            def to_local(self):
+                return self._local
+
+            def __getattr__(self, name):
+                return getattr(self._local, name)
+
+        cache_holder = nn.Module()
+
+        results = []
+        for step in range(2):
+            dV_raw = torch.randn(k_low, M, dtype=torch.float64)
+            dV_ref = dV_raw - (dV_raw @ V_full.T) @ V_full
+
+            V_low = nn.Parameter(torch.randn(k_low, M, dtype=torch.float64))
+            V_low.grad = dV_raw.clone()
+
+            svd_dict = {
+                "U_high": torch.randn(1, 1, dtype=torch.float64),
+                "S_high": torch.randn(k_high, dtype=torch.float64),
+                "V_high": FakeShardedTensor(local_shard),
+                "U_low": nn.Parameter(torch.randn(1, 1, dtype=torch.float64)),
+                "S_low": nn.Parameter(torch.randn(1, dtype=torch.float64)),
+                "V_low": V_low,
+                "rank_high": k_high,
+            }
+
+            project_gradient_to_orthogonal_space(svd_dict, skip_u=True, cache_holder=cache_holder)
+            results.append((V_low.grad.clone(), dV_ref))
+
+        # Step 1 should have called all_gather; step 2 should have used cache
+        assert gather_call_count == 1, f"Expected 1 all_gather call, got {gather_call_count}"
+        assert hasattr(cache_holder, "_osft_v_high_full"), "Cache was not populated"
+
+        # Both steps must match reference
+        for step, (projected, ref) in enumerate(results):
+            assert torch.allclose(projected, ref, atol=1e-10), (
+                f"Step {step}: projection wrong, max |diff| = {(projected - ref).abs().max().item():.2e}"
+            )
+
+        # Cached tensor must equal the full V_high (not the padded gathered buffer)
+        assert cache_holder._osft_v_high_full.shape == (k_high, M), (
+            f"Cached shape {cache_holder._osft_v_high_full.shape} != expected ({k_high}, {M})"
+        )
+        assert torch.allclose(cache_holder._osft_v_high_full, V_full, atol=1e-10), (
+            "Cached V_high differs from original — may contain padding"
+        )
 
 
 class TestLazyInitTokenizerAlignment:

--- a/tests/test_osft.py
+++ b/tests/test_osft.py
@@ -1589,6 +1589,327 @@ class TestBatchedUAllReduce:
             )
 
 
+class TestVProjectionCache:
+    """Test V_high caching in factored V projection."""
+
+    def _create_simple_osft_model(self, hidden_size=32, rank_ratio=0.5):
+        """Create a simple model with OSFT for testing."""
+
+        class SimpleModel(nn.Module):
+            def __init__(self, config, **kwargs):
+                super().__init__()
+                self.config = config
+                self.linear = nn.Linear(hidden_size, hidden_size, bias=False)
+                self.dtype = torch.float32
+                nn.init.normal_(self.linear.weight, mean=0.0, std=0.02)
+
+        OSFTModelClass = create_osft_model_class(SimpleModel)
+        config = MagicMock()
+        config.vocab_size = 1000
+        osft_config = {"linear.weight": int(hidden_size * rank_ratio)}
+
+        model = OSFTModelClass(
+            config=config,
+            osft_config={},
+            initialize_osft=False,
+            upcast_dtype=torch.float32,
+            output_dtype=torch.float32,
+        )
+        model.osft_config = osft_config
+        model.osft_unfreeze_rank_ratio = rank_ratio
+        model.reinitialize_osft(decompose_existing_weights=True)
+        return model
+
+    def test_cache_populated_after_first_projection(self, monkeypatch):
+        """V_high cache should be set on the module after the first call."""
+        monkeypatch.setattr(osft_module, "OSFT_CACHE_V", True)
+        model = self._create_simple_osft_model()
+        model.train()
+
+        # Before projection: no cache
+        for module in model.modules():
+            if hasattr(module, "osft_params"):
+                assert not hasattr(module, "_osft_v_high_full")
+
+        # Forward + backward
+        x = torch.randn(4, 32)
+        loss = model.linear(x).pow(2).sum()
+        loss.backward()
+
+        model.project_gradients()
+
+        # After projection: cache should exist
+        cached_count = 0
+        for module in model.modules():
+            if hasattr(module, "_osft_v_high_full"):
+                cached_count += 1
+                V = module._osft_v_high_full
+                assert V.ndim == 2
+                # Cached V_high should match V_high shape (k_high, M)
+                assert V.shape == module.osft_V_high.shape
+        assert cached_count > 0
+
+    def test_cached_v_high_matches_original(self, monkeypatch):
+        """Cached V_high should be identical to the original V_high (single GPU)."""
+        monkeypatch.setattr(osft_module, "OSFT_CACHE_V", True)
+        model = self._create_simple_osft_model()
+        model.train()
+
+        x = torch.randn(4, 32)
+        loss = model.linear(x).pow(2).sum()
+        loss.backward()
+        model.project_gradients()
+
+        for module in model.modules():
+            if hasattr(module, "_osft_v_high_full") and hasattr(module, "osft_V_high"):
+                cached = module._osft_v_high_full
+                original = module.osft_V_high
+                assert torch.equal(cached, original), "Cached V_high differs from original"
+
+    def test_cache_smaller_than_gram(self, monkeypatch):
+        """Cached V_high (k_high, M) should be smaller than the Gram matrix (M, M)."""
+        monkeypatch.setattr(osft_module, "OSFT_CACHE_V", True)
+        model = self._create_simple_osft_model(hidden_size=32, rank_ratio=0.5)
+        model.train()
+
+        x = torch.randn(4, 32)
+        loss = model.linear(x).pow(2).sum()
+        loss.backward()
+        model.project_gradients()
+
+        for module in model.modules():
+            if hasattr(module, "_osft_v_high_full") and hasattr(module, "osft_V_high"):
+                V = module._osft_v_high_full
+                M = V.shape[1]
+                cache_elements = V.nelement()         # k_high * M
+                gram_elements = M * M                  # M * M
+                assert cache_elements < gram_elements, (
+                    f"Cache ({cache_elements}) should be smaller than Gram ({gram_elements})"
+                )
+
+    def test_factored_matches_gram_projection(self):
+        """Factored V projection should produce the same result as Gram-based projection."""
+        torch.manual_seed(42)
+        model = self._create_simple_osft_model(hidden_size=32, rank_ratio=0.5)
+        model.train()
+
+        # Get V_high for manual Gram-based projection
+        V_high = None
+        for module in model.modules():
+            if hasattr(module, "osft_V_high"):
+                V_high = module.osft_V_high.clone()
+                break
+        assert V_high is not None
+
+        # Forward + backward
+        x = torch.randn(4, 32)
+        loss = model.linear(x).pow(2).sum()
+        loss.backward()
+
+        # Save raw gradient before projection
+        for module in model.modules():
+            if hasattr(module, "osft_V_high") and hasattr(module, "osft_params"):
+                raw_dV = module.osft_params.V_low.grad.clone()
+                break
+
+        # Apply factored projection (the actual code path)
+        model.project_gradients()
+
+        for module in model.modules():
+            if hasattr(module, "osft_V_high") and hasattr(module, "osft_params"):
+                factored_result = module.osft_params.V_low.grad.clone()
+                break
+
+        # Compute Gram-based projection manually for comparison
+        G = V_high.T @ V_high
+        gram_result = raw_dV - raw_dV @ G
+
+        assert torch.allclose(factored_result, gram_result, atol=1e-6), (
+            f"Factored and Gram projections differ: max diff = "
+            f"{(factored_result - gram_result).abs().max().item()}"
+        )
+
+    def test_factored_matches_gram_rectangular(self):
+        """Factored and Gram agree for rectangular weights (the down_proj-like 7x case).
+
+        For down_proj, N < M so k_high = min(N,M)/2 is small relative to M.
+        This exercises the high-ratio regime where the factored form saves 7x.
+        """
+        torch.manual_seed(42)
+        # Mimic down_proj shape ratio: N=16, M=56 → k_high=8, M=56 → ratio=7x
+        N, M = 16, 56
+        k_high = N // 2  # 8
+        k_low = N - k_high  # 8
+
+        # Create orthonormal V_high (k_high, M) via QR
+        V_high = torch.linalg.qr(torch.randn(M, k_high))[0].T  # (k_high, M)
+        assert V_high.shape == (k_high, M)
+
+        dV = torch.randn(k_low, M)
+
+        # Gram form: dV - dV @ (V_high^T @ V_high)
+        G = V_high.T @ V_high  # (M, M) = (56, 56)
+        gram_result = dV - dV @ G
+
+        # Factored form: dV - (dV @ V_high^T) @ V_high
+        coeff = dV @ V_high.T  # (k_low, k_high) = (8, 8)
+        factored_result = dV - coeff @ V_high
+
+        # Verify sizes confirm the 7x ratio
+        assert G.nelement() == M * M  # 3136
+        assert V_high.nelement() == k_high * M  # 448
+        assert G.nelement() / V_high.nelement() == M / k_high  # 7.0
+
+        assert torch.allclose(factored_result, gram_result, atol=1e-6), (
+            f"Factored and Gram differ for rectangular case: max diff = "
+            f"{(factored_result - gram_result).abs().max().item()}"
+        )
+
+    def test_projection_identical_with_and_without_cache(self, monkeypatch):
+        """Projection results should be identical whether or not the cache is used."""
+        monkeypatch.setattr(osft_module, "OSFT_CACHE_V", True)
+        torch.manual_seed(42)
+        model = self._create_simple_osft_model()
+        model.train()
+
+        # Step 1: populates cache
+        x = torch.randn(4, 32)
+        loss = model.linear(x).pow(2).sum()
+        loss.backward()
+        model.project_gradients()
+
+        osft_params = [p for n, p in model.named_parameters() if "osft_params" in n]
+        optimizer = torch.optim.SGD(osft_params, lr=1e-3)
+        optimizer.step()
+        optimizer.zero_grad()
+
+        # Step 2: uses cache — save projected gradient
+        x2 = torch.randn(4, 32)
+        loss2 = model.linear(x2).pow(2).sum()
+        loss2.backward()
+        model.project_gradients()
+
+        grad_with_cache = {}
+        for module in model.modules():
+            if hasattr(module, "osft_V_high"):
+                grad_with_cache["V_low"] = module.osft_params.V_low.grad.clone()
+                grad_with_cache["U_low"] = module.osft_params.U_low.grad.clone()
+
+        # Now clear cache and redo the same step
+        optimizer.zero_grad()
+        for module in model.modules():
+            if hasattr(module, "_osft_v_high_full"):
+                del module._osft_v_high_full
+
+        loss2b = model.linear(x2).pow(2).sum()
+        loss2b.backward()
+        model.project_gradients()
+
+        for module in model.modules():
+            if hasattr(module, "osft_V_high"):
+                assert torch.equal(module.osft_params.V_low.grad, grad_with_cache["V_low"]), (
+                    "V_low gradient differs with vs without cache"
+                )
+                assert torch.equal(module.osft_params.U_low.grad, grad_with_cache["U_low"]), (
+                    "U_low gradient differs with vs without cache"
+                )
+
+    def test_cache_disabled_by_default(self):
+        """Cache should not be populated when OSFT_CACHE_V is at its default (off)."""
+
+        model = self._create_simple_osft_model()
+        model.train()
+
+        x = torch.randn(4, 32)
+        loss = model.linear(x).pow(2).sum()
+        loss.backward()
+        model.project_gradients()
+
+        for module in model.modules():
+            assert not hasattr(module, "_osft_v_high_full"), (
+                "Cache should not be populated when OSFT_CACHE_V is disabled"
+            )
+
+    def test_orthogonality_maintained_with_cache(self, monkeypatch):
+        """Orthogonality must hold across multiple steps with caching active."""
+        monkeypatch.setattr(osft_module, "OSFT_CACHE_V", True)
+        model = self._create_simple_osft_model()
+        model.train()
+        tracker = OrthogonalityTracker(margin_deg=1.0)
+
+        osft_params = [p for n, p in model.named_parameters() if "osft_params" in n]
+        optimizer = torch.optim.AdamW(osft_params, lr=1e-4)
+        optim_wrapper(optimizer, model)
+
+        for step in range(1, 11):
+            x = torch.randn(4, 32)
+            loss = model.linear(x).pow(2).sum()
+            loss.backward()
+
+            # project_gradients is called inside optim_wrapper's step()
+            optimizer.step()
+
+            for module in model.modules():
+                if (
+                    hasattr(module, "osft_params")
+                    and hasattr(module, "osft_U_high")
+                    and hasattr(module, "osft_S_high")
+                    and hasattr(module, "osft_V_high")
+                ):
+                    check_parameter_orthogonality(model, module, step, tracker)
+
+            optimizer.zero_grad()
+
+        assert tracker.is_successful(), f"Orthogonality violated with V_high caching:\n{tracker.get_summary()}"
+
+    def test_cache_cleared_by_reset_osft_metadata(self, monkeypatch):
+        """_reset_osft_metadata must clear cached V_high tensors.
+
+        reinitialize_osft calls _reset_osft_metadata, which creates new V_high
+        tensors.  Any cached all-gathered V_high from the old decomposition
+        would be stale.  This test verifies the cache is cleared.
+        """
+        monkeypatch.setattr(osft_module, "OSFT_CACHE_V", True)
+        model = self._create_simple_osft_model()
+        model.train()
+
+        # Populate cache
+        x = torch.randn(4, 32)
+        loss = model.linear(x).pow(2).sum()
+        loss.backward()
+        model.project_gradients()
+
+        # Verify cache exists
+        cached_modules = [m for m in model.modules() if hasattr(m, "_osft_v_high_full")]
+        assert len(cached_modules) > 0, "Cache should be populated before reset"
+
+        # _reset_osft_metadata is the mechanism reinitialize_osft uses
+        model._reset_osft_metadata()
+
+        # Cache must be gone
+        for module in model.modules():
+            assert not hasattr(module, "_osft_v_high_full"), "Cache was not cleared by _reset_osft_metadata"
+
+    def test_cache_not_in_state_dict(self, monkeypatch):
+        """Cached V_high tensors must not appear in model state_dict."""
+        monkeypatch.setattr(osft_module, "OSFT_CACHE_V", True)
+        model = self._create_simple_osft_model()
+        model.train()
+
+        x = torch.randn(4, 32)
+        loss = model.linear(x).pow(2).sum()
+        loss.backward()
+        model.project_gradients()
+
+        # Verify cache exists
+        assert any(hasattr(m, "_osft_v_high_full") for m in model.modules())
+
+        # Verify it's not in state_dict
+        sd = model.state_dict()
+        for key in sd:
+            assert "_osft_v_high_full" not in key, f"Cache leaked into state_dict: {key}"
+
+
 class TestLazyInitTokenizerAlignment:
     """Ensure memory-efficient loading aligns tokenizers before broadcasting."""
 


### PR DESCRIPTION
Fixes #73 
Replace dV -= dV @ (V_high^T @ V_high) with the factored form dV -= (dV @ V_high^T) @ V_high.  Under FSDP2 this replaces an (M, M) all-reduce with a (k_high, M) all-gather — M/k_high fewer bytes (2x for square weights, 7x for down_proj) and all-gather is cheaper per byte.

Add opt-in caching of the all-gathered V_high (OSFT_CACHE_V=1, default off).  V_high is frozen, so the cache is exact.

Includes bench_v_proj.py benchmark and 10 new tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional caching of the full V_high tensor to avoid repeated distributed gathers and speed V-gradient projection
  * Command-line benchmark script to compare Gram, factored, and cached V-projection performance across multi-GPU setups

* **Bug Fixes / Improvements**
  * Switched V-projection to a factored update path that handles uneven shard layouts and leverages the cache when available
  * Ensures caches are cleared on reinitialization and not persisted into model state

* **Tests**
  * Extensive tests covering caching behavior, uneven-shard de-interleaving, correctness vs. Gram-based projection, cache clearing, and no-leak guarantees
<!-- end of auto-generated comment: release notes by coderabbit.ai -->