### PR TITLE
Fix Gemma 3 VLM detection for dual-registered configs

### DIFF
--- a/src/mini_trainer/setup_model_for_training.py
+++ b/src/mini_trainer/setup_model_for_training.py
@@ -68,9 +68,25 @@ def _apply_liger_kernels_if_requested(use_liger_kernels, model_config, base_mode
         ) from e
 
     model_type = getattr(model_config, "model_type", None)
+
+    # For VLM models that were extracted to their text backbone, the config
+    # may still carry the parent VLM model_type. Try the text_config's
+    # model_type as a fallback.
     apply_fn = MODEL_TYPE_TO_APPLY_LIGER_FN.get(model_type)
     if apply_fn is None:
-        raise ValueError(f"Liger kernels do not support model type '{model_type}'.")
+        text_config = getattr(model_config, "text_config", None)
+        text_model_type = getattr(text_config, "model_type", None) if text_config else None
+        if text_model_type:
+            apply_fn = MODEL_TYPE_TO_APPLY_LIGER_FN.get(text_model_type)
+            if apply_fn is not None:
+                model_type = text_model_type
+
+    if apply_fn is None:
+        log_rank_0(
+            f"⚠️  Liger kernels do not support model type '{model_type}' — "
+            f"skipping Liger optimization. Training will proceed without it."
+        )
+        return
 
     apply_signature = inspect.signature(apply_fn)
     liger_kwargs = {}

--- a/src/mini_trainer/utils.py
+++ b/src/mini_trainer/utils.py
@@ -152,7 +152,15 @@ def get_model_class_from_config(model_path):
 
     config_class = config.__class__
     if config_class in mapping:
-        return mapping[config_class]
+        resolved_cls = mapping[config_class]
+        # Some models (e.g. Gemma 3) are dual-registered: the top-level config
+        # maps to a ForConditionalGeneration VLM, not a text-only CausalLM.
+        # In that case, prefer the text_config's CausalLM class instead.
+        if "ForConditionalGeneration" in resolved_cls.__name__:
+            text_config = getattr(config, "text_config", None)
+            if text_config is not None and text_config.__class__ in mapping:
+                return mapping[text_config.__class__]
+        return resolved_cls
 
     # Fallback: for VLM models that wrap a CausalLM text backbone
     # (e.g. Mistral3Config wrapping Ministral3Config), check text_config

--- a/src/mini_trainer/vlm_utils.py
+++ b/src/mini_trainer/vlm_utils.py
@@ -19,10 +19,14 @@ from mini_trainer.utils import log_rank_0
 def is_vlm_with_causal_lm(config) -> bool:
     """Check if a model config is a VLM wrapping a CausalLM text backbone.
 
-    Returns True only when the top-level config is NOT in the CausalLM
-    mapping but its nested ``text_config`` IS.  Models that are directly
-    registered as CausalLM (even if they also have a text_config) return
-    False.
+    Returns True when the model needs VLM extraction to obtain the trainable
+    CausalLM sub-model.  This covers two cases:
+
+    1. The top-level config is NOT in the CausalLM mapping but its nested
+       ``text_config`` IS (e.g. Ministral-3 / Mistral3ForConditionalGeneration).
+    2. The top-level config IS in the CausalLM mapping, but the resolved class
+       is a ``ForConditionalGeneration`` VLM (e.g. Gemma 3, which is
+       dual-registered so ``AutoModelForCausalLM`` loads the full VLM).
 
     Args:
         config: An already-loaded HuggingFace model config object.
@@ -30,9 +34,19 @@ def is_vlm_with_causal_lm(config) -> bool:
     Returns:
         True if the model is a VLM wrapping a CausalLM text backbone.
     """
-    if config.__class__ in MODEL_FOR_CAUSAL_LM_MAPPING:
-        return False
     text_config = getattr(config, "text_config", None)
+
+    if config.__class__ in MODEL_FOR_CAUSAL_LM_MAPPING:
+        # Check what class AutoModelForCausalLM would actually load.
+        # Some models (e.g. Gemma 3) are dual-registered and resolve to
+        # a ForConditionalGeneration VLM, which still needs extraction.
+        resolved_cls = MODEL_FOR_CAUSAL_LM_MAPPING[config.__class__]
+        if "ForConditionalGeneration" not in resolved_cls.__name__:
+            return False
+        if text_config is None:
+            return False
+        return text_config.__class__ in MODEL_FOR_CAUSAL_LM_MAPPING
+
     return text_config is not None and text_config.__class__ in MODEL_FOR_CAUSAL_LM_MAPPING
 
 


### PR DESCRIPTION
## Summary

Same fix as https://github.com/instructlab/training/pull/695 but for mini_trainer.

`is_vlm_with_causal_lm()` returns `False` for Gemma 3 because `Gemma3Config` is dual-registered in both `MODEL_FOR_CAUSAL_LM_MAPPING` and `MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING`. The function bails out early when the config is in the CausalLM mapping, but `AutoModelForCausalLM` actually resolves to `Gemma3ForConditionalGeneration` (a full VLM), not a text-only CausalLM.

The fix checks what class the mapping resolves to. If it's a `ForConditionalGeneration` VLM, the model is treated as needing backbone extraction.

**Note**: The extraction itself works correctly, but `Gemma3ForCausalLM.__init__` then fails with `'Gemma3TextConfig' object has no attribute 'vision_config'` — that's a separate issue in the transformers Gemma 3 model code where the CausalLM class references `self.config.vision_config` during init, which doesn't exist on `Gemma3TextConfig`. This PR fixes the detection logic; the transformers bug will need a separate upstream fix.

## Test plan

- [x] Verified routing for all models: text-only models (Qwen2, Llama, Granite, Mistral) still use `AutoModelForCausalLM`, VLMs with extractable backbones (Gemma 3, Gemma 3n, Ministral, Mistral3-VLM) correctly route to `extract_causal_lm`, VLMs without CausalLM variant (Qwen3-VL) use `direct_vlm_load`
- [x] Gemma 3 backbone extraction succeeds (logs show `✅ Extracted Gemma3ForCausalLM successfully`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vision–language model detection and model-class resolution to better handle dual-registered configurations, reducing misclassification and improving selection of text-generation components.
  * Liger kernel application now falls back to the model's text-config type when available and otherwise skips with a warning instead of erroring, avoiding hard failures for unsupported types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->