### PR TITLE
feat: add on-demand full-state checkpointing for OSFT training resumption

### DIFF
--- a/docs/superpowers/specs/2026-04-02-full-state-checkpointing-design.md
+++ b/docs/superpowers/specs/2026-04-02-full-state-checkpointing-design.md
@@ -1,0 +1,140 @@
+# Full-State On-Demand Checkpointing for mini_trainer
+
+## Problem
+
+When training OSFT models in Kubernetes/OpenShift/SLURM environments, pods can be preempted at any time. Currently, mini_trainer only saves model weights (reconstructed to dense format) at epoch/sample boundaries. There is no way to resume training from the exact mid-training state, meaning all progress since the last checkpoint is lost.
+
+## Goal
+
+Implement signal-driven full-state checkpointing that:
+1. Catches termination signals and saves complete training state before exit
+2. Uses DCP sharded saves (each rank saves its shard, no gathering to rank 0)
+3. Preserves the exact optimization trajectory on resume: `f(x1) -> save -> load -> f(x2)` must be bit-identical to `f(x1) -> f(x2)`
+4. Saves the OSFT model in decomposed format (SVD factors, not reconstructed dense weights)
+
+## Architecture
+
+### New module: `src/mini_trainer/full_state_checkpoint.py`
+
+Contains `FullStateCheckpointer` class with:
+- `install_signal_handlers()` — registers handlers for 7 signals
+- `should_save(device)` — polls trigger file + `all_reduce(MAX)` consensus
+- `save(...)` — DCP sharded save + per-rank RNG + rank-0 metadata
+- `load(...)` — DCP sharded load + state restoration (static/classmethod)
+- `cleanup()` — removes trigger file
+
+### Signals handled
+
+SIGTERM, SIGINT, SIGUSR1, SIGUSR2, SIGXCPU, SIGHUP, SIGQUIT — covers Kubernetes, SLURM, PBS, LSF, and interactive use.
+
+### Trigger mechanism
+
+Signal handler writes a trigger file to `/dev/shm/mini_trainer_checkpoint_trigger`. Workers poll this file at batch boundaries (after `take_gradient_step()`). `all_reduce(MAX)` ensures all ranks agree. After save, trigger file is removed and processes exit cleanly.
+
+### Checkpoint contents
+
+**Sharded via `dcp.save()` (all ranks, no gathering):**
+- Model state dict — OSFT factors (U/S/V_high, U/S/V_low) in decomposed form
+- Optimizer state dict — AdamW momentum/variance, sharded to match model
+
+**Per-rank via `torch.save()` (each rank saves its own):**
+- RNG states: torch CPU, torch CUDA, python random, numpy
+
+**Global via `torch.save()` (rank 0 only):**
+- Training counters: step, epoch, total_samples_accumulated, total_tokens_processed
+- last_validation_loss
+- LR scheduler state dict
+- Checkpointer state: last_saved_samples, last_frequency_saved_samples, best_val_loss
+- Sampler epoch + accumulated samples (for batch-skipping on resume)
+- OSFT config dict (sanity check on resume)
+
+### Directory layout
+
+```
+<output_dir>/full_state_checkpoints/step_<N>/
+  .metadata, __*_*.distcp     (DCP shards)
+  rng_state_rank_*.pt          (per-rank RNG)
+  training_state.pt            (global metadata, rank 0)
+```
+
+### Resume flow
+
+On resume (`--resume-from-full-state-checkpoint <path>`):
+
+1. `setup_model()` runs normally — loads model from pretrained on rank 0, applies all monkey-patches (loss function, Liger kernels, Mamba kernels, OSFT forward overrides), creates model structure on all ranks
+2. `prepare_model_for_fsdp2()` — creates OSFT param structure with correct shapes on meta device
+3. `wrap_fsdp2()` — FSDP2 shards the structure
+4. `finalize_model_initialization()` — **skips `compute_distributed_svd()`**, instead uses `dcp.load()` to fill in parameter values from checkpoint
+5. Create optimizer with OSFT wrapping — normal path
+6. Load optimizer state from DCP checkpoint
+7. Restore LR scheduler state, RNG states, training counters, checkpointer state
+8. Resume training loop from saved step/epoch, skip already-processed batches
+
+Key: SVD is NOT recomputed. The model structure (shapes, forward overrides, parameter registrations) is set up by the existing init pipeline. DCP load fills in the actual values.
+
+### Monkey-patches that survive naturally
+
+All monkey-patches are applied by the existing `setup_model()` / `setup_training_components()` pipeline, which runs before DCP load:
+- Loss function patches (HF fixed_cross_entropy -> none_reduction)
+- Liger kernel patches (via `_apply_liger_kernels_if_requested()`)
+- Mamba-SSM kernel patches
+- OSFT forward overrides (via `_pre_fsdp2_wrap_initialize_lazy_osft()`)
+- Optimizer step wrapping (via `optim_wrapper()`)
+- Config assignments (use_cache=False, torch_dtype, etc.)
+
+### Training loop integration
+
+One polling point per batch, after `take_gradient_step()`:
+
+```python
+if full_state_checkpointer and full_state_checkpointer.should_save(device):
+    full_state_checkpointer.save(...)
+    full_state_checkpointer.cleanup()
+    sys.exit(0)
+```
+
+### Config additions
+
+In `TrainingArgs` (training_types.py):
+- `on_demand_checkpointing: bool = False`
+- `resume_from_full_state_checkpoint: str | None = None`
+
+### Separate from existing checkpoints
+
+Full-state checkpoints are independent of the existing epoch/min_samples/best_val_loss checkpoint system. They are opaque resume tokens for this system only.
+
+### Same-topology assumption
+
+Initial implementation assumes same world size on resume. DCP's sharded format supports resharding, making future support straightforward.
+
+## Test plan
+
+### Test 1: Unit tests (pytest, no GPU)
+- Signal handler writes trigger file
+- Trigger detection and cleanup
+- Metadata serialization roundtrip
+- Config field parsing
+
+### Test 2: Single-process save/load roundtrip (pytest, single GPU)
+- Tiny inline model with OSFT
+- Save and load, assert bit-identical model/optimizer/scheduler/RNG state
+
+### Test 3: Optimization trajectory fidelity (torchrun, multi-GPU) — CRITICAL
+- Qwen2.5-0.5B-Instruct, OSFT mode
+- Run A: 20 steps baseline, record loss/grad_norm/param_hash/lr per step
+- Run B: 10 steps -> checkpoint -> resume -> 10 more steps, record same metrics
+- Assert steps 11-20 are identical between Run A and Run B
+
+### Test 4: Multi-node simulation (torchrun, 2 NUMA domains)
+- Same as Test 3 but with 2 simulated nodes: GPUs 0-3 (node 0) and GPUs 4-7 (node 1)
+- Validates DCP sharded save/load across node boundaries
+
+### Test 5: Signal-triggered end-to-end
+- Launch training with --on-demand-checkpointing
+- Send SIGUSR1 after a few steps
+- Verify checkpoint directory structure, clean exit, and successful resume
+
+### Test 6: Edge cases
+- Checkpoint at step 1
+- Checkpoint at epoch boundary
+- SFT mode (non-OSFT, no SVD factors)

--- a/regression_tests/run_multi_node_fidelity_test.sh
+++ b/regression_tests/run_multi_node_fidelity_test.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 
 MODEL="${1:-/tmp/tiny_qwen2}"
 DATA="${2:-/tmp/tiny_test.jsonl}"
-OUTPUT_DIR="${3:-/mnt/nvme3n1/workspace/osilkin/pr-repos/async-checkpointing/mini_trainer/multi_node_fidelity_output}"
+OUTPUT_DIR="${3:-/tmp/multi_node_fidelity_output}"
 TOTAL_STEPS=20
 CHECKPOINT_STEP=10
 SCRIPT="regression_tests/test_full_state_checkpoint_fidelity.py"

--- a/regression_tests/run_multi_node_fidelity_test.sh
+++ b/regression_tests/run_multi_node_fidelity_test.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Multi-node fidelity test for full-state checkpointing.
+# Simulates 2 nodes using NUMA-pinned GPU groups: node0=GPUs 0-3, node1=GPUs 4-7.
+#
+# Usage: ./regression_tests/run_multi_node_fidelity_test.sh [model] [data] [output_dir]
+
+set -euo pipefail
+
+MODEL="${1:-/tmp/tiny_qwen2}"
+DATA="${2:-/tmp/tiny_test.jsonl}"
+OUTPUT_DIR="${3:-/mnt/nvme3n1/workspace/osilkin/pr-repos/async-checkpointing/mini_trainer/multi_node_fidelity_output}"
+TOTAL_STEPS=20
+CHECKPOINT_STEP=10
+SCRIPT="regression_tests/test_full_state_checkpoint_fidelity.py"
+MASTER_PORT=29500
+
+rm -rf "$OUTPUT_DIR"
+mkdir -p "$OUTPUT_DIR"
+
+run_two_nodes() {
+    local mode="$1"
+    shift
+    echo "=== Running mode=$mode (2 nodes x 4 GPUs) ==="
+
+    # Find a free port to avoid conflicts
+    MASTER_PORT=$((29500 + RANDOM % 1000))
+
+    CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun \
+        --nnodes=2 --nproc-per-node=4 --node-rank=0 \
+        --master-addr=localhost --master-port=$MASTER_PORT \
+        "$SCRIPT" --model-name-or-path "$MODEL" --data-path "$DATA" \
+        --mode "$mode" --total-steps "$TOTAL_STEPS" \
+        --output-dir "$OUTPUT_DIR" "$@" &
+    PID0=$!
+
+    CUDA_VISIBLE_DEVICES=4,5,6,7 torchrun \
+        --nnodes=2 --nproc-per-node=4 --node-rank=1 \
+        --master-addr=localhost --master-port=$MASTER_PORT \
+        "$SCRIPT" --model-name-or-path "$MODEL" --data-path "$DATA" \
+        --mode "$mode" --total-steps "$TOTAL_STEPS" \
+        --output-dir "$OUTPUT_DIR" "$@" &
+    PID1=$!
+
+    # Wait for both nodes
+    wait "$PID0"
+    STATUS0=$?
+    wait "$PID1"
+    STATUS1=$?
+
+    if [ $STATUS0 -ne 0 ] || [ $STATUS1 -ne 0 ]; then
+        echo "FAIL: mode=$mode failed (node0=$STATUS0, node1=$STATUS1)"
+        exit 1
+    fi
+    echo "=== mode=$mode complete ==="
+}
+
+echo "========================================"
+echo "Multi-Node Fidelity Test"
+echo "  Model: $MODEL"
+echo "  Data: $DATA"
+echo "  Steps: $TOTAL_STEPS"
+echo "  Checkpoint at: step $CHECKPOINT_STEP"
+echo "  Output: $OUTPUT_DIR"
+echo "========================================"
+
+# Run A: baseline (20 steps straight through)
+run_two_nodes baseline
+
+# Run B part 1: checkpoint at step 10
+run_two_nodes checkpoint --checkpoint-at-step "$CHECKPOINT_STEP"
+
+# Run B part 2: resume from checkpoint
+run_two_nodes resume --checkpoint-at-step "$CHECKPOINT_STEP"
+
+# Compare trajectories
+echo "=== Comparing trajectories ==="
+python "$SCRIPT" --mode compare --output-dir "$OUTPUT_DIR"

--- a/regression_tests/test_checkpoint_all_models.py
+++ b/regression_tests/test_checkpoint_all_models.py
@@ -62,8 +62,9 @@ MODELS = {
     },
 }
 
-DATA_PATH = "/tmp/ckpt_validation/data.jsonl"
-BASE_OUTPUT = "/tmp/ckpt_validation/runs"
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DATA_PATH = os.path.join(_REPO_ROOT, ".test_artifacts", "messages_data.jsonl")
+BASE_OUTPUT = os.path.join(_REPO_ROOT, ".test_artifacts", "runs")
 TRIGGER_FILE = "/dev/shm/mini_trainer_checkpoint_trigger"
 NUM_GPUS = 8
 
@@ -219,7 +220,7 @@ def test_model(model_key, model_info, use_liger):
 
     # Wait for process to exit
     try:
-        proc.wait(timeout=300)
+        proc.wait(timeout=1200)
     except subprocess.TimeoutExpired:
         print(f"  [{tag}] FAIL: Training didn't exit after trigger (timeout)")
         proc.kill()
@@ -270,7 +271,7 @@ def test_model(model_key, model_info, use_liger):
     )
 
     try:
-        proc2.wait(timeout=600)
+        proc2.wait(timeout=1800)
     except subprocess.TimeoutExpired:
         print(f"  [{tag}] FAIL: Resume timed out")
         proc2.kill()

--- a/regression_tests/test_checkpoint_all_models.py
+++ b/regression_tests/test_checkpoint_all_models.py
@@ -77,9 +77,16 @@ def clean_trigger():
         pass
 
 
-def run_osft_training(model_id, output_dir, use_liger, trust_remote_code,
-                      osft_target_patterns, on_demand=False, resume_path=None,
-                      max_steps=30):
+def run_osft_training(
+    model_id,
+    output_dir,
+    use_liger,
+    trust_remote_code,
+    osft_target_patterns,
+    on_demand=False,
+    resume_path=None,
+    max_steps=30,
+):
     """Launch OSFT training via training_hub.osft() and return the process."""
     # Use training_hub's osft function via a subprocess python call
     # This handles data processing + torchrun automatically
@@ -117,12 +124,17 @@ osft(
     {("osft_target_patterns='" + osft_target_patterns + "',") if osft_target_patterns else ""}
 )
 """
+    # Write stdout to a log file instead of PIPE to avoid blocking on
+    # grandchild processes (torchrun workers) that inherit the pipe.
+    log_path = os.path.join(output_dir, "subprocess.log")
+    log_fh = open(log_path, "w")
     proc = subprocess.Popen(
-        [sys.executable, "-c", script],
-        stdout=subprocess.PIPE,
+        [sys.executable, "-u", "-c", script],
+        stdout=log_fh,
         stderr=subprocess.STDOUT,
-        text=True,
     )
+    proc._log_fh = log_fh  # keep reference for cleanup
+    proc._log_path = log_path
     return proc
 
 
@@ -139,7 +151,7 @@ def wait_for_steps(output_dir, min_steps=5, timeout=600):
                         lines = sum(1 for _ in fh)
                     if lines >= min_steps:
                         return True
-                except (IOError, OSError):
+                except OSError:
                     pass
         time.sleep(2)
     return False
@@ -164,9 +176,9 @@ def test_model(model_key, model_info, use_liger):
     tag = f"{model_key}_{liger_str}"
     output_dir = os.path.join(BASE_OUTPUT, tag)
 
-    print(f"\n{'='*70}")
+    print(f"\n{'=' * 70}")
     print(f"  {tag}: {model_info['model_id']}")
-    print(f"{'='*70}")
+    print(f"{'=' * 70}")
 
     # Clean up from any previous run
     if os.path.exists(output_dir):
@@ -192,7 +204,7 @@ def test_model(model_key, model_info, use_liger):
         # Check if process died (OOM or other error)
         ret = proc.poll()
         if ret is not None:
-            output = proc.stdout.read()
+            output = open(proc._log_path).read() if hasattr(proc, "_log_path") else ""
             if "CUDA out of memory" in output or "OutOfMemoryError" in output:
                 print(f"  [{tag}] SKIP: OOM — model too large for {NUM_GPUS} GPUs")
                 shutil.rmtree(output_dir, ignore_errors=True)
@@ -228,7 +240,8 @@ def test_model(model_key, model_info, use_liger):
         shutil.rmtree(output_dir, ignore_errors=True)
         return "fail"
 
-    output_phase1 = proc.stdout.read()
+    proc._log_fh.close()
+    output_phase1 = open(proc._log_path).read()
 
     # Check exit code
     if proc.returncode != 0:
@@ -280,7 +293,8 @@ def test_model(model_key, model_info, use_liger):
         shutil.rmtree(resume_dir, ignore_errors=True)
         return "fail"
 
-    output_phase2 = proc2.stdout.read()
+    proc2._log_fh.close()
+    output_phase2 = open(proc2._log_path).read()
 
     if proc2.returncode != 0:
         if "CUDA out of memory" in output_phase2 or "OutOfMemoryError" in output_phase2:
@@ -316,9 +330,9 @@ def main():
             results[tag] = result
 
     # Summary
-    print(f"\n{'='*70}")
+    print(f"\n{'=' * 70}")
     print("  RESULTS SUMMARY")
-    print(f"{'='*70}")
+    print(f"{'=' * 70}")
     passes = sum(1 for v in results.values() if v == "pass")
     fails = sum(1 for v in results.values() if v == "fail")
     skips = sum(1 for v in results.values() if v.startswith("skip"))

--- a/regression_tests/test_checkpoint_all_models.py
+++ b/regression_tests/test_checkpoint_all_models.py
@@ -23,7 +23,7 @@ import subprocess
 import sys
 import time
 
-# Models from model_validation.py — using real HF model IDs
+# All models from model_validation.py
 MODELS = {
     "llama": {
         "model_id": "meta-llama/Llama-3.2-1B-Instruct",
@@ -35,8 +35,18 @@ MODELS = {
         "trust_remote_code": False,
         "osft_target_patterns": None,
     },
+    "qwen3": {
+        "model_id": "qwen/Qwen3-4B-Instruct-2507",
+        "trust_remote_code": False,
+        "osft_target_patterns": None,
+    },
     "granite": {
         "model_id": "ibm-granite/granite-3.1-8b-instruct",
+        "trust_remote_code": False,
+        "osft_target_patterns": None,
+    },
+    "granite-moe": {
+        "model_id": "ibm-granite/granite-4.0-h-tiny",
         "trust_remote_code": False,
         "osft_target_patterns": None,
     },
@@ -45,8 +55,38 @@ MODELS = {
         "trust_remote_code": False,
         "osft_target_patterns": None,
     },
+    "gemma3": {
+        "model_id": "google/gemma-3-4b-it",
+        "trust_remote_code": False,
+        "osft_target_patterns": None,
+    },
+    "gemma3n": {
+        "model_id": "google/gemma-3n-E4B-it",
+        "trust_remote_code": False,
+        "osft_target_patterns": None,
+    },
     "mistral": {
         "model_id": "mistralai/Mistral-7B-Instruct-v0.3",
+        "trust_remote_code": False,
+        "osft_target_patterns": None,
+    },
+    "ministral": {
+        "model_id": "mistralai/Ministral-3-3B-Instruct-2512",
+        "trust_remote_code": False,
+        "osft_target_patterns": None,
+    },
+    "mistral3-vlm": {
+        "model_id": "mistralai/Ministral-3-3B-Reasoning-2512",
+        "trust_remote_code": False,
+        "osft_target_patterns": None,
+    },
+    "qwen3-vl": {
+        "model_id": "Qwen/Qwen3-VL-2B-Instruct",
+        "trust_remote_code": False,
+        "osft_target_patterns": None,
+    },
+    "qwen3.5": {
+        "model_id": "Qwen/Qwen3.5-4B",
         "trust_remote_code": False,
         "osft_target_patterns": None,
     },
@@ -55,8 +95,8 @@ MODELS = {
         "trust_remote_code": True,
         "osft_target_patterns": "q_proj,k_proj,v_proj,o_proj",
     },
-    "granite-moe": {
-        "model_id": "ibm-granite/granite-4.0-h-tiny",
+    "gpt-oss": {
+        "model_id": "openai/gpt-oss-20b",
         "trust_remote_code": False,
         "osft_target_patterns": None,
     },

--- a/regression_tests/test_checkpoint_all_models.py
+++ b/regression_tests/test_checkpoint_all_models.py
@@ -1,0 +1,339 @@
+"""
+Test full-state checkpointing with all supported model architectures.
+
+For each model x liger mode:
+1. Run OSFT training with --on-demand-checkpointing
+2. Write trigger file to /dev/shm after a few steps
+3. Verify checkpoint was saved and training exited cleanly
+4. Resume from checkpoint
+5. Verify resumed training completes
+6. Clean up artifacts
+
+Skips models that OOM on available GPUs.
+
+Usage:
+    python regression_tests/test_checkpoint_all_models.py
+"""
+
+import json
+import os
+import shutil
+import signal
+import subprocess
+import sys
+import time
+
+# Models from model_validation.py — using real HF model IDs
+MODELS = {
+    "llama": {
+        "model_id": "meta-llama/Llama-3.2-1B-Instruct",
+        "trust_remote_code": False,
+        "osft_target_patterns": None,
+    },
+    "qwen2": {
+        "model_id": "qwen/Qwen2.5-1.5B-Instruct",
+        "trust_remote_code": False,
+        "osft_target_patterns": None,
+    },
+    "granite": {
+        "model_id": "ibm-granite/granite-3.1-8b-instruct",
+        "trust_remote_code": False,
+        "osft_target_patterns": None,
+    },
+    "phi4": {
+        "model_id": "microsoft/Phi-4-mini-instruct",
+        "trust_remote_code": False,
+        "osft_target_patterns": None,
+    },
+    "mistral": {
+        "model_id": "mistralai/Mistral-7B-Instruct-v0.3",
+        "trust_remote_code": False,
+        "osft_target_patterns": None,
+    },
+    "nemotron": {
+        "model_id": "nvidia/NVIDIA-Nemotron-Nano-9B-v2",
+        "trust_remote_code": True,
+        "osft_target_patterns": "q_proj,k_proj,v_proj,o_proj",
+    },
+    "granite-moe": {
+        "model_id": "ibm-granite/granite-4.0-h-tiny",
+        "trust_remote_code": False,
+        "osft_target_patterns": None,
+    },
+}
+
+DATA_PATH = "/tmp/ckpt_validation/data.jsonl"
+BASE_OUTPUT = "/tmp/ckpt_validation/runs"
+TRIGGER_FILE = "/dev/shm/mini_trainer_checkpoint_trigger"
+NUM_GPUS = 8
+
+
+def clean_trigger():
+    """Remove stale trigger file."""
+    try:
+        os.unlink(TRIGGER_FILE)
+    except FileNotFoundError:
+        pass
+
+
+def run_osft_training(model_id, output_dir, use_liger, trust_remote_code,
+                      osft_target_patterns, on_demand=False, resume_path=None,
+                      max_steps=30):
+    """Launch OSFT training via training_hub.osft() and return the process."""
+    # Use training_hub's osft function via a subprocess python call
+    # This handles data processing + torchrun automatically
+    script = f"""
+import os, sys
+sys.path.insert(0, '/mnt/nvme3n1/workspace/osilkin/pr-repos/async-checkpointing/training_hub/src')
+sys.path.insert(0, '/mnt/nvme3n1/workspace/osilkin/pr-repos/async-checkpointing/mini_trainer/src')
+from training_hub import osft
+
+osft(
+    model_path="{model_id}",
+    data_path="{DATA_PATH}",
+    ckpt_output_dir="{output_dir}",
+    unfreeze_rank_ratio=0.5,
+    num_epochs=1,
+    effective_batch_size=8,
+    learning_rate=1e-4,
+    max_seq_len=512,
+    max_tokens_per_gpu=512,
+    data_output_dir="{output_dir}/_data",
+    warmup_steps=0,
+    use_liger={use_liger},
+    seed=42,
+    lr_scheduler="cosine",
+    checkpoint_at_epoch=False,
+    save_final_checkpoint=False,
+    trust_remote_code={trust_remote_code},
+    nproc_per_node={NUM_GPUS},
+    nnodes=1,
+    node_rank=0,
+    training_mode="step",
+    max_steps={max_steps},
+    on_demand_checkpointing={on_demand},
+    {"resume_from_full_state_checkpoint='" + resume_path + "'," if resume_path else ""}
+    {("osft_target_patterns='" + osft_target_patterns + "',") if osft_target_patterns else ""}
+)
+"""
+    proc = subprocess.Popen(
+        [sys.executable, "-c", script],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    return proc
+
+
+def wait_for_steps(output_dir, min_steps=5, timeout=600):
+    """Wait until training has logged at least min_steps metric lines."""
+    start = time.time()
+    while time.time() - start < timeout:
+        # Look for metrics file
+        for f in os.listdir(output_dir) if os.path.isdir(output_dir) else []:
+            if f.startswith("training_metrics_") and f.endswith(".jsonl"):
+                path = os.path.join(output_dir, f)
+                try:
+                    with open(path) as fh:
+                        lines = sum(1 for _ in fh)
+                    if lines >= min_steps:
+                        return True
+                except (IOError, OSError):
+                    pass
+        time.sleep(2)
+    return False
+
+
+def find_checkpoint_dir(output_dir):
+    """Find the full-state checkpoint directory."""
+    ckpt_base = os.path.join(output_dir, "full_state_checkpoints")
+    if not os.path.isdir(ckpt_base):
+        return None
+    steps = [d for d in os.listdir(ckpt_base) if d.startswith("step_")]
+    if not steps:
+        return None
+    # Return the latest
+    steps.sort(key=lambda x: int(x.split("_")[1]))
+    return os.path.join(ckpt_base, steps[-1])
+
+
+def test_model(model_key, model_info, use_liger):
+    """Test checkpoint save + resume for a single model/liger combo."""
+    liger_str = "liger" if use_liger else "no-liger"
+    tag = f"{model_key}_{liger_str}"
+    output_dir = os.path.join(BASE_OUTPUT, tag)
+
+    print(f"\n{'='*70}")
+    print(f"  {tag}: {model_info['model_id']}")
+    print(f"{'='*70}")
+
+    # Clean up from any previous run
+    if os.path.exists(output_dir):
+        shutil.rmtree(output_dir)
+    os.makedirs(output_dir, exist_ok=True)
+    clean_trigger()
+
+    # Phase 1: Run training with on-demand checkpointing
+    print(f"  [{tag}] Phase 1: Training with on-demand checkpointing...")
+    proc = run_osft_training(
+        model_id=model_info["model_id"],
+        output_dir=output_dir,
+        use_liger=use_liger,
+        trust_remote_code=model_info["trust_remote_code"],
+        osft_target_patterns=model_info.get("osft_target_patterns"),
+        on_demand=True,
+        max_steps=100,  # enough steps that we can trigger mid-training
+    )
+
+    # Wait for training to produce steps
+    started = wait_for_steps(output_dir, min_steps=5, timeout=600)
+    if not started:
+        # Check if process died (OOM or other error)
+        ret = proc.poll()
+        if ret is not None:
+            output = proc.stdout.read()
+            if "CUDA out of memory" in output or "OutOfMemoryError" in output:
+                print(f"  [{tag}] SKIP: OOM — model too large for {NUM_GPUS} GPUs")
+                shutil.rmtree(output_dir, ignore_errors=True)
+                return "skip_oom"
+            else:
+                print(f"  [{tag}] FAIL: Training crashed before producing steps")
+                # Save log for debugging
+                log_path = os.path.join(output_dir, "crash.log")
+                with open(log_path, "w") as f:
+                    f.write(output)
+                print(f"    Log saved to {log_path}")
+                print(f"    Last 5 lines: {output.strip().split(chr(10))[-5:]}")
+                shutil.rmtree(output_dir, ignore_errors=True)
+                return "fail"
+        print(f"  [{tag}] FAIL: Timed out waiting for training to start")
+        proc.kill()
+        proc.wait()
+        shutil.rmtree(output_dir, ignore_errors=True)
+        return "fail"
+
+    # Write trigger file
+    print(f"  [{tag}] Writing trigger file...")
+    with open(TRIGGER_FILE, "w") as f:
+        pass
+
+    # Wait for process to exit
+    try:
+        proc.wait(timeout=300)
+    except subprocess.TimeoutExpired:
+        print(f"  [{tag}] FAIL: Training didn't exit after trigger (timeout)")
+        proc.kill()
+        proc.wait()
+        shutil.rmtree(output_dir, ignore_errors=True)
+        return "fail"
+
+    output_phase1 = proc.stdout.read()
+
+    # Check exit code
+    if proc.returncode != 0:
+        # Check for OOM
+        if "CUDA out of memory" in output_phase1 or "OutOfMemoryError" in output_phase1:
+            print(f"  [{tag}] SKIP: OOM during training")
+            shutil.rmtree(output_dir, ignore_errors=True)
+            return "skip_oom"
+        print(f"  [{tag}] FAIL: Training exited with code {proc.returncode}")
+        print(f"    Last 3 lines: {output_phase1.strip().split(chr(10))[-3:]}")
+        shutil.rmtree(output_dir, ignore_errors=True)
+        return "fail"
+
+    # Find checkpoint
+    ckpt_dir = find_checkpoint_dir(output_dir)
+    if ckpt_dir is None:
+        print(f"  [{tag}] FAIL: No checkpoint directory found")
+        shutil.rmtree(output_dir, ignore_errors=True)
+        return "fail"
+
+    print(f"  [{tag}] Checkpoint saved at {os.path.basename(ckpt_dir)}")
+
+    # Phase 2: Resume from checkpoint
+    print(f"  [{tag}] Phase 2: Resuming from checkpoint...")
+    resume_dir = os.path.join(BASE_OUTPUT, f"{tag}_resumed")
+    if os.path.exists(resume_dir):
+        shutil.rmtree(resume_dir)
+    os.makedirs(resume_dir, exist_ok=True)
+    clean_trigger()
+
+    proc2 = run_osft_training(
+        model_id=model_info["model_id"],
+        output_dir=resume_dir,
+        use_liger=use_liger,
+        trust_remote_code=model_info["trust_remote_code"],
+        osft_target_patterns=model_info.get("osft_target_patterns"),
+        on_demand=False,
+        resume_path=ckpt_dir,
+        max_steps=30,  # just needs to run a few more steps
+    )
+
+    try:
+        proc2.wait(timeout=600)
+    except subprocess.TimeoutExpired:
+        print(f"  [{tag}] FAIL: Resume timed out")
+        proc2.kill()
+        proc2.wait()
+        shutil.rmtree(output_dir, ignore_errors=True)
+        shutil.rmtree(resume_dir, ignore_errors=True)
+        return "fail"
+
+    output_phase2 = proc2.stdout.read()
+
+    if proc2.returncode != 0:
+        if "CUDA out of memory" in output_phase2 or "OutOfMemoryError" in output_phase2:
+            print(f"  [{tag}] SKIP: OOM during resume")
+            shutil.rmtree(output_dir, ignore_errors=True)
+            shutil.rmtree(resume_dir, ignore_errors=True)
+            return "skip_oom"
+        print(f"  [{tag}] FAIL: Resume exited with code {proc2.returncode}")
+        print(f"    Last 3 lines: {output_phase2.strip().split(chr(10))[-3:]}")
+        shutil.rmtree(output_dir, ignore_errors=True)
+        shutil.rmtree(resume_dir, ignore_errors=True)
+        return "fail"
+
+    print(f"  [{tag}] PASS")
+
+    # Clean up
+    shutil.rmtree(output_dir, ignore_errors=True)
+    shutil.rmtree(resume_dir, ignore_errors=True)
+    return "pass"
+
+
+def main():
+    print("Full-State Checkpoint Validation — All Model Architectures")
+    print(f"GPUs: {NUM_GPUS}, Data: {DATA_PATH}")
+    print()
+
+    results = {}
+    for model_key, model_info in MODELS.items():
+        for use_liger in [False, True]:
+            liger_str = "liger" if use_liger else "no-liger"
+            tag = f"{model_key}_{liger_str}"
+            result = test_model(model_key, model_info, use_liger)
+            results[tag] = result
+
+    # Summary
+    print(f"\n{'='*70}")
+    print("  RESULTS SUMMARY")
+    print(f"{'='*70}")
+    passes = sum(1 for v in results.values() if v == "pass")
+    fails = sum(1 for v in results.values() if v == "fail")
+    skips = sum(1 for v in results.values() if v.startswith("skip"))
+    print(f"  PASS: {passes}  FAIL: {fails}  SKIP: {skips}  TOTAL: {len(results)}")
+    print()
+    for tag, result in results.items():
+        icon = {"pass": "OK", "fail": "FAIL", "skip_oom": "SKIP(OOM)"}
+        print(f"  {icon.get(result, result):>10}  {tag}")
+
+    # Clean up base output if empty
+    if os.path.exists(BASE_OUTPUT) and not os.listdir(BASE_OUTPUT):
+        shutil.rmtree(BASE_OUTPUT)
+
+    if fails > 0:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/regression_tests/test_full_state_checkpoint_fidelity.py
+++ b/regression_tests/test_full_state_checkpoint_fidelity.py
@@ -1,0 +1,282 @@
+"""
+Full-state checkpoint fidelity test.
+
+Proves that the optimization trajectory after checkpoint/resume is
+bit-identical to a continuous run.
+
+Run A (baseline):   Train 20 steps, record metrics at each step.
+Run B (checkpoint):  Train 10 steps, checkpoint, restart, train 10 more steps.
+Compare:             Steps 11-20 must be identical between A and B.
+
+Usage:
+    # Run A: baseline (20 steps straight through)
+    CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun --nnodes=1 --nproc-per-node=4 \
+        regression_tests/test_full_state_checkpoint_fidelity.py \
+        --mode baseline --total-steps 20 --output-dir /tmp/fidelity_test
+
+    # Run B part 1: train 10 steps then checkpoint
+    CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun --nnodes=1 --nproc-per-node=4 \
+        regression_tests/test_full_state_checkpoint_fidelity.py \
+        --mode checkpoint --checkpoint-at-step 10 --total-steps 20 \
+        --output-dir /tmp/fidelity_test
+
+    # Run B part 2: resume from checkpoint, train 10 more steps
+    CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun --nnodes=1 --nproc-per-node=4 \
+        regression_tests/test_full_state_checkpoint_fidelity.py \
+        --mode resume --total-steps 20 --output-dir /tmp/fidelity_test
+
+    # Compare trajectories
+    python regression_tests/test_full_state_checkpoint_fidelity.py \
+        --mode compare --output-dir /tmp/fidelity_test
+"""
+
+import argparse
+import hashlib
+import os
+import sys
+
+import torch
+import torch.distributed as dist
+
+
+def hash_parameters(model: torch.nn.Module) -> str:
+    """Create a deterministic hash of all trainable model parameters.
+
+    Only hashes local shards to avoid expensive all-gather operations.
+    """
+    h = hashlib.sha256()
+    for name, param in sorted(model.named_parameters()):
+        if not param.requires_grad:
+            continue
+        h.update(name.encode())
+        # Use local tensor for DTensor to avoid all-gather
+        p = param.detach()
+        if hasattr(p, '_local_tensor'):
+            p = p._local_tensor
+        h.update(p.float().cpu().numpy().tobytes())
+    return h.hexdigest()
+
+
+def record_step_metrics(step, loss, grad_norm, lr, param_hash):
+    return {
+        "step": step,
+        "loss": loss,
+        "grad_norm": grad_norm,
+        "lr": lr,
+        "param_hash": param_hash,
+    }
+
+
+def run_training(args, checkpoint_at_step=None, resume_checkpoint=None):
+    """Run training and record per-step metrics."""
+    from mini_trainer.setup_model_for_training import setup_model, setup_training_components
+    from mini_trainer.sampler import get_data_loader
+    from mini_trainer.utils import init_distributed_environment, set_seed
+    from mini_trainer.full_state_checkpoint import FullStateCheckpointer
+    # Use inline gradient step to avoid validate_training_state dtype checks
+    def take_gradient_step(model, optimizer, lr_scheduler):
+        grad_norm = torch.nn.utils.clip_grad_norm_(model.parameters(), 1.0)
+        optimizer.step()
+        lr_scheduler.step()
+        optimizer.zero_grad()
+        return grad_norm
+
+    init_distributed_environment()
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    set_seed(42)
+
+    # Setup model
+    model = setup_model(
+        model_name_or_path=args.model_name_or_path,
+        osft=True,
+        osft_rank_ratio=0.8,  # unfreeze 20%
+        use_liger_kernels=False,
+        train_dtype=torch.bfloat16,
+        trust_remote_code=args.trust_remote_code,
+    )
+
+    model, optimizer, lr_scheduler = setup_training_components(
+        model=model,
+        learning_rate=1e-4,
+        num_warmup_steps=2,
+        lr_scheduler="cosine",
+        num_training_steps=args.total_steps,
+        resume_from_checkpoint=resume_checkpoint,
+    )
+
+    data_loader, _ = get_data_loader(
+        data_path=args.data_path,
+        batch_size=2,
+        max_tokens_per_gpu=512,
+        seed=42,
+    )
+
+    device = next(model.parameters()).device
+    metrics = []
+
+    # If resuming, load optimizer + RNG + metadata
+    start_step = 0
+    start_epoch = 0
+    if resume_checkpoint:
+        meta = FullStateCheckpointer.load_metadata(resume_checkpoint)
+        start_step = meta["step"]
+        start_epoch = meta["epoch"]
+        lr_scheduler.load_state_dict(meta["lr_scheduler_state"])
+        FullStateCheckpointer.load_rng_states(resume_checkpoint, rank)
+
+        # Load optimizer state from DCP
+        from torch.distributed.checkpoint.state_dict import get_optimizer_state_dict, set_optimizer_state_dict
+        import torch.distributed.checkpoint as dcp_module
+        optim_state = get_optimizer_state_dict(model, optimizer)
+        dcp_module.load({"optimizer": optim_state}, checkpoint_id=str(resume_checkpoint + "/distributed"))
+        set_optimizer_state_dict(model, optimizer, optim_state)
+
+        data_loader.sampler.set_epoch(meta["sampler_epoch"])
+
+    model.train()
+    step = 0
+    for epoch in range(start_epoch, 100):  # enough to cover total_steps
+        data_loader.sampler.set_epoch(epoch)
+        for batch in data_loader:
+            # Skip batches if resuming
+            if step < start_step:
+                step += 1
+                continue
+
+            for mb in batch:
+                model_inputs = {
+                    "input_ids": mb["input_ids"].to(device),
+                    "labels": mb["labels"].to(device),
+                }
+                if (pos_ids := mb.get("position_ids")) is not None:
+                    model_inputs["position_ids"] = pos_ids.to(device)
+                if (attn_mask := mb.get("attention_mask")) is not None:
+                    model_inputs["attention_mask"] = attn_mask.to(device)
+
+                output = model(**model_inputs)
+                loss = output.loss.float().sum()
+                batch_tokens = mb["batch_num_loss_counted_tokens"]
+                loss = (loss / batch_tokens) * world_size
+                loss.backward()
+                torch.cuda.empty_cache()
+
+            step += 1
+            current_lr = lr_scheduler.get_last_lr()[0]
+            grad_norm = take_gradient_step(model, optimizer, lr_scheduler)
+
+            if rank == 0:
+                metrics.append(record_step_metrics(
+                    step=step,
+                    loss=loss.detach().cpu().item(),
+                    grad_norm=grad_norm.item(),
+                    lr=current_lr,
+                    param_hash=hash_parameters(model),
+                ))
+                print(f"  step={step} loss={loss.detach().cpu().item():.6f} grad_norm={grad_norm.item():.6f} lr={current_lr:.8f}")
+
+            dist.barrier()
+
+            # Checkpoint if requested
+            if checkpoint_at_step and step == checkpoint_at_step:
+                checkpointer = FullStateCheckpointer(
+                    checkpoint_dir=os.path.join(args.output_dir, "full_state_checkpoints"),
+                    rank=rank,
+                    world_size=world_size,
+                )
+                checkpointer.save(
+                    model=model,
+                    optimizer=optimizer,
+                    lr_scheduler=lr_scheduler,
+                    training_state={
+                        "step": step,
+                        "epoch": epoch,
+                        "total_samples_accumulated": step * 2,
+                        "total_tokens_processed": 0,
+                        "last_validation_loss": None,
+                    },
+                    checkpointer_state={
+                        "last_saved_samples": 0,
+                        "last_frequency_saved_samples": 0,
+                        "best_val_loss": None,
+                    },
+                    data_loader=data_loader,
+                    device=device,
+                )
+                if rank == 0:
+                    torch.save(metrics, os.path.join(args.output_dir, "trajectory_first_half.pt"))
+                    print(f"Checkpoint saved at step {step}. Exiting.")
+                dist.destroy_process_group()
+                sys.exit(0)
+
+            if step >= args.total_steps:
+                break
+        if step >= args.total_steps:
+            break
+
+    # Save metrics
+    if rank == 0:
+        suffix = "baseline" if not resume_checkpoint else "resumed"
+        torch.save(metrics, os.path.join(args.output_dir, f"trajectory_{suffix}.pt"))
+        print(f"Saved {len(metrics)} step metrics as trajectory_{suffix}.pt")
+
+    dist.destroy_process_group()
+
+
+def compare_trajectories(output_dir):
+    """Compare baseline and resumed trajectories step by step."""
+    baseline = torch.load(os.path.join(output_dir, "trajectory_baseline.pt"), weights_only=False)
+    first_half = torch.load(os.path.join(output_dir, "trajectory_first_half.pt"), weights_only=False)
+    resumed = torch.load(os.path.join(output_dir, "trajectory_resumed.pt"), weights_only=False)
+
+    combined = first_half + resumed
+
+    if len(baseline) != len(combined):
+        print(f"FIDELITY TEST FAILED: trajectory length mismatch baseline={len(baseline)}, combined={len(combined)}")
+        sys.exit(1)
+
+    mismatches = []
+    for b, c in zip(baseline, combined):
+        step = b["step"]
+        if b["loss"] != c["loss"]:
+            mismatches.append(f"Step {step}: loss {b['loss']} != {c['loss']}")
+        if b["grad_norm"] != c["grad_norm"]:
+            mismatches.append(f"Step {step}: grad_norm {b['grad_norm']} != {c['grad_norm']}")
+        if b["param_hash"] != c["param_hash"]:
+            mismatches.append(f"Step {step}: param_hash mismatch")
+        if b["lr"] != c["lr"]:
+            mismatches.append(f"Step {step}: lr {b['lr']} != {c['lr']}")
+
+    if mismatches:
+        print("FIDELITY TEST FAILED")
+        for m in mismatches:
+            print(f"  {m}")
+        sys.exit(1)
+    else:
+        print(f"FIDELITY TEST PASSED: all {len(baseline)} steps match")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", choices=["baseline", "checkpoint", "resume", "compare"], required=True)
+    parser.add_argument("--model-name-or-path", default="Qwen/Qwen2.5-0.5B-Instruct")
+    parser.add_argument("--data-path", default="test.jsonl")
+    parser.add_argument("--total-steps", type=int, default=20)
+    parser.add_argument("--checkpoint-at-step", type=int, default=10)
+    parser.add_argument("--output-dir", default="/tmp/fidelity_test")
+    parser.add_argument("--trust-remote-code", action="store_true")
+    args = parser.parse_args()
+
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    if args.mode == "baseline":
+        run_training(args)
+    elif args.mode == "checkpoint":
+        run_training(args, checkpoint_at_step=args.checkpoint_at_step)
+    elif args.mode == "resume":
+        ckpt_dir = os.path.join(
+            args.output_dir, "full_state_checkpoints", f"step_{args.checkpoint_at_step}"
+        )
+        run_training(args, resume_checkpoint=ckpt_dir)
+    elif args.mode == "compare":
+        compare_trajectories(args.output_dir)

--- a/regression_tests/test_full_state_checkpoint_fidelity.py
+++ b/regression_tests/test_full_state_checkpoint_fidelity.py
@@ -127,12 +127,17 @@ def run_training(args, checkpoint_at_step=None, resume_checkpoint=None):
         lr_scheduler.load_state_dict(meta["lr_scheduler_state"])
         FullStateCheckpointer.load_rng_states(resume_checkpoint, rank)
 
-        # Load optimizer state from DCP (same approach as production code)
-        import torch.distributed.checkpoint as dcp_module
-
-        optim_state = optimizer.state_dict()
-        dcp_module.load({"optimizer": optim_state}, checkpoint_id=str(Path(resume_checkpoint) / "distributed"))
-        optimizer.load_state_dict(optim_state)
+        # Pre-populate optimizer state entries with zeros (matching DTensor structure)
+        # so load_optimizer_state can overwrite them with checkpoint values.
+        for group in optimizer.param_groups:
+            for p in group["params"]:
+                if p not in optimizer.state:
+                    optimizer.state[p] = {
+                        "step": torch.tensor(0.0),
+                        "exp_avg": torch.zeros_like(p),
+                        "exp_avg_sq": torch.zeros_like(p),
+                    }
+        FullStateCheckpointer.load_optimizer_state(resume_checkpoint, optimizer, rank)
 
         data_loader.sampler.set_epoch(meta["sampler_epoch"])
 
@@ -145,6 +150,17 @@ def run_training(args, checkpoint_at_step=None, resume_checkpoint=None):
             if step < start_step:
                 step += 1
                 continue
+
+            # Snapshot RNG at step start for checkpoint fidelity
+            import random as _random
+
+            _rng_snapshot = {
+                "torch_rng": torch.get_rng_state(),
+                "python_rng": _random.getstate(),
+                "numpy_rng": __import__("numpy").random.get_state(),
+            }
+            if torch.cuda.is_available():
+                _rng_snapshot["cuda_rng"] = torch.cuda.get_rng_state()
 
             for mb in batch:
                 model_inputs = {
@@ -208,6 +224,7 @@ def run_training(args, checkpoint_at_step=None, resume_checkpoint=None):
                     },
                     data_loader=data_loader,
                     device=device,
+                    rng_snapshot=_rng_snapshot,
                 )
                 if rank == 0:
                     torch.save(metrics, os.path.join(args.output_dir, "trajectory_first_half.pt"))

--- a/regression_tests/test_full_state_checkpoint_fidelity.py
+++ b/regression_tests/test_full_state_checkpoint_fidelity.py
@@ -51,7 +51,7 @@ def hash_parameters(model: torch.nn.Module) -> str:
         h.update(name.encode())
         # Use local tensor for DTensor to avoid all-gather
         p = param.detach()
-        if hasattr(p, '_local_tensor'):
+        if hasattr(p, "_local_tensor"):
             p = p._local_tensor
         h.update(p.float().cpu().numpy().tobytes())
     return h.hexdigest()
@@ -69,10 +69,11 @@ def record_step_metrics(step, loss, grad_norm, lr, param_hash):
 
 def run_training(args, checkpoint_at_step=None, resume_checkpoint=None):
     """Run training and record per-step metrics."""
-    from mini_trainer.setup_model_for_training import setup_model, setup_training_components
-    from mini_trainer.sampler import get_data_loader
-    from mini_trainer.utils import init_distributed_environment, set_seed
     from mini_trainer.full_state_checkpoint import FullStateCheckpointer
+    from mini_trainer.sampler import get_data_loader
+    from mini_trainer.setup_model_for_training import setup_model, setup_training_components
+    from mini_trainer.utils import init_distributed_environment, set_seed
+
     # Use inline gradient step to avoid validate_training_state dtype checks
     def take_gradient_step(model, optimizer, lr_scheduler):
         grad_norm = torch.nn.utils.clip_grad_norm_(model.parameters(), 1.0)
@@ -126,8 +127,9 @@ def run_training(args, checkpoint_at_step=None, resume_checkpoint=None):
         FullStateCheckpointer.load_rng_states(resume_checkpoint, rank)
 
         # Load optimizer state from DCP
-        from torch.distributed.checkpoint.state_dict import get_optimizer_state_dict, set_optimizer_state_dict
         import torch.distributed.checkpoint as dcp_module
+        from torch.distributed.checkpoint.state_dict import get_optimizer_state_dict, set_optimizer_state_dict
+
         optim_state = get_optimizer_state_dict(model, optimizer)
         dcp_module.load({"optimizer": optim_state}, checkpoint_id=str(resume_checkpoint + "/distributed"))
         set_optimizer_state_dict(model, optimizer, optim_state)
@@ -166,14 +168,18 @@ def run_training(args, checkpoint_at_step=None, resume_checkpoint=None):
             grad_norm = take_gradient_step(model, optimizer, lr_scheduler)
 
             if rank == 0:
-                metrics.append(record_step_metrics(
-                    step=step,
-                    loss=loss.detach().cpu().item(),
-                    grad_norm=grad_norm.item(),
-                    lr=current_lr,
-                    param_hash=hash_parameters(model),
-                ))
-                print(f"  step={step} loss={loss.detach().cpu().item():.6f} grad_norm={grad_norm.item():.6f} lr={current_lr:.8f}")
+                metrics.append(
+                    record_step_metrics(
+                        step=step,
+                        loss=loss.detach().cpu().item(),
+                        grad_norm=grad_norm.item(),
+                        lr=current_lr,
+                        param_hash=hash_parameters(model),
+                    )
+                )
+                print(
+                    f"  step={step} loss={loss.detach().cpu().item():.6f} grad_norm={grad_norm.item():.6f} lr={current_lr:.8f}"
+                )
 
             dist.barrier()
 
@@ -274,9 +280,7 @@ if __name__ == "__main__":
     elif args.mode == "checkpoint":
         run_training(args, checkpoint_at_step=args.checkpoint_at_step)
     elif args.mode == "resume":
-        ckpt_dir = os.path.join(
-            args.output_dir, "full_state_checkpoints", f"step_{args.checkpoint_at_step}"
-        )
+        ckpt_dir = os.path.join(args.output_dir, "full_state_checkpoints", f"step_{args.checkpoint_at_step}")
         run_training(args, resume_checkpoint=ckpt_dir)
     elif args.mode == "compare":
         compare_trajectories(args.output_dir)

--- a/regression_tests/test_full_state_checkpoint_fidelity.py
+++ b/regression_tests/test_full_state_checkpoint_fidelity.py
@@ -34,6 +34,7 @@ import argparse
 import hashlib
 import os
 import sys
+from pathlib import Path
 
 import torch
 import torch.distributed as dist
@@ -131,7 +132,7 @@ def run_training(args, checkpoint_at_step=None, resume_checkpoint=None):
         from torch.distributed.checkpoint.state_dict import get_optimizer_state_dict, set_optimizer_state_dict
 
         optim_state = get_optimizer_state_dict(model, optimizer)
-        dcp_module.load({"optimizer": optim_state}, checkpoint_id=str(resume_checkpoint + "/distributed"))
+        dcp_module.load({"optimizer": optim_state}, checkpoint_id=str(Path(resume_checkpoint) / "distributed"))
         set_optimizer_state_dict(model, optimizer, optim_state)
 
         data_loader.sampler.set_epoch(meta["sampler_epoch"])
@@ -212,6 +213,7 @@ def run_training(args, checkpoint_at_step=None, resume_checkpoint=None):
                 if rank == 0:
                     torch.save(metrics, os.path.join(args.output_dir, "trajectory_first_half.pt"))
                     print(f"Checkpoint saved at step {step}. Exiting.")
+                dist.barrier()
                 dist.destroy_process_group()
                 sys.exit(0)
 

--- a/regression_tests/test_full_state_checkpoint_fidelity.py
+++ b/regression_tests/test_full_state_checkpoint_fidelity.py
@@ -127,13 +127,12 @@ def run_training(args, checkpoint_at_step=None, resume_checkpoint=None):
         lr_scheduler.load_state_dict(meta["lr_scheduler_state"])
         FullStateCheckpointer.load_rng_states(resume_checkpoint, rank)
 
-        # Load optimizer state from DCP
+        # Load optimizer state from DCP (same approach as production code)
         import torch.distributed.checkpoint as dcp_module
-        from torch.distributed.checkpoint.state_dict import get_optimizer_state_dict, set_optimizer_state_dict
 
-        optim_state = get_optimizer_state_dict(model, optimizer)
+        optim_state = optimizer.state_dict()
         dcp_module.load({"optimizer": optim_state}, checkpoint_id=str(Path(resume_checkpoint) / "distributed"))
-        set_optimizer_state_dict(model, optimizer, optim_state)
+        optimizer.load_state_dict(optim_state)
 
         data_loader.sampler.set_epoch(meta["sampler_epoch"])
 
@@ -215,7 +214,7 @@ def run_training(args, checkpoint_at_step=None, resume_checkpoint=None):
                     print(f"Checkpoint saved at step {step}. Exiting.")
                 dist.barrier()
                 dist.destroy_process_group()
-                sys.exit(0)
+                os._exit(0)
 
             if step >= args.total_steps:
                 break

--- a/regression_tests/test_full_state_checkpoint_signal.sh
+++ b/regression_tests/test_full_state_checkpoint_signal.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# Test that writing the trigger file causes training to checkpoint and exit cleanly.
+#
+# Usage: ./regression_tests/test_full_state_checkpoint_signal.sh [model] [data]
+
+set -euo pipefail
+
+MODEL="${1:-/tmp/tiny_qwen2}"
+DATA="${2:-/tmp/tiny_test.jsonl}"
+OUTPUT_DIR="/mnt/nvme3n1/workspace/osilkin/pr-repos/async-checkpointing/mini_trainer/signal_test_output"
+TRIGGER_FILE="/dev/shm/mini_trainer_checkpoint_trigger"
+
+rm -rf "$OUTPUT_DIR"
+mkdir -p "$OUTPUT_DIR"
+rm -f "$TRIGGER_FILE"
+
+echo "========================================"
+echo "Signal-Triggered Checkpoint Test"
+echo "  Model: $MODEL"
+echo "  Output: $OUTPUT_DIR"
+echo "========================================"
+
+echo "=== Phase 1: Start training with on-demand checkpointing ==="
+CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun --nnodes=1 --nproc-per-node=4 \
+    -m mini_trainer.train \
+    --model-name-or-path "$MODEL" \
+    --data-path "$DATA" \
+    --batch-size 2 \
+    --max-tokens-per-gpu 512 \
+    --learning-rate 1e-4 \
+    --output-dir "$OUTPUT_DIR" \
+    --training-mode infinite \
+    --osft \
+    --osft-unfreeze-rank-ratio 0.2 \
+    --on-demand-checkpointing \
+    > "$OUTPUT_DIR/train.log" 2>&1 &
+
+TRAIN_PID=$!
+echo "Training PID: $TRAIN_PID"
+
+# Wait for training to produce at least 5 metric lines
+echo "Waiting for training to start..."
+STARTED=false
+for i in $(seq 1 180); do
+    METRICS_FILE=$(ls "$OUTPUT_DIR"/training_metrics_*.jsonl 2>/dev/null | head -1)
+    if [ -n "$METRICS_FILE" ]; then
+        LINES=$(wc -l < "$METRICS_FILE")
+        if [ "$LINES" -ge 5 ]; then
+            echo "Training running — $LINES steps logged"
+            STARTED=true
+            break
+        fi
+    fi
+    # Check if process died
+    if ! kill -0 "$TRAIN_PID" 2>/dev/null; then
+        echo "FAIL: Training process died before producing steps"
+        cat "$OUTPUT_DIR/train.log" | tail -20
+        exit 1
+    fi
+    sleep 2
+done
+
+if [ "$STARTED" = false ]; then
+    echo "FAIL: Training did not start within timeout"
+    kill -9 "$TRAIN_PID" 2>/dev/null
+    exit 1
+fi
+
+# Write trigger file (this is what signal handlers do in production)
+echo "=== Writing trigger file: $TRIGGER_FILE ==="
+touch "$TRIGGER_FILE"
+
+# Wait for clean exit
+echo "Waiting for training to checkpoint and exit..."
+EXITED=false
+for i in $(seq 1 120); do
+    if ! kill -0 "$TRAIN_PID" 2>/dev/null; then
+        wait "$TRAIN_PID" 2>/dev/null
+        EXIT_CODE=$?
+        echo "Training exited with code: $EXIT_CODE"
+        EXITED=true
+        break
+    fi
+    sleep 2
+done
+
+if [ "$EXITED" = false ]; then
+    echo "FAIL: Training did not exit within timeout"
+    kill -9 "$TRAIN_PID" 2>/dev/null
+    exit 1
+fi
+
+echo ""
+echo "=== Phase 2: Verify checkpoint structure ==="
+
+CKPT_DIR="$OUTPUT_DIR/full_state_checkpoints"
+if [ ! -d "$CKPT_DIR" ]; then
+    echo "FAIL: No checkpoint directory at $CKPT_DIR"
+    exit 1
+fi
+
+STEP_DIR=$(ls -d "$CKPT_DIR"/step_* 2>/dev/null | head -1)
+if [ -z "$STEP_DIR" ]; then
+    echo "FAIL: No step directory in $CKPT_DIR"
+    exit 1
+fi
+
+echo "Checkpoint directory: $STEP_DIR"
+
+# Check DCP distributed directory
+if [ ! -d "$STEP_DIR/distributed" ]; then
+    echo "FAIL: No distributed/ directory in checkpoint"
+    exit 1
+fi
+echo "  OK: distributed/ directory exists"
+
+# Check metadata
+if [ ! -f "$STEP_DIR/training_state.pt" ]; then
+    echo "FAIL: No training_state.pt"
+    exit 1
+fi
+echo "  OK: training_state.pt exists"
+
+# Check per-rank RNG files
+for r in 0 1 2 3; do
+    if [ ! -f "$STEP_DIR/rng_state_rank_${r}.pt" ]; then
+        echo "FAIL: Missing rng_state_rank_${r}.pt"
+        exit 1
+    fi
+done
+echo "  OK: rng_state_rank_{0..3}.pt all present"
+
+# Check DCP shard files
+SHARD_COUNT=$(ls "$STEP_DIR/distributed/"__*_*.distcp 2>/dev/null | wc -l)
+if [ "$SHARD_COUNT" -lt 4 ]; then
+    echo "FAIL: Expected at least 4 DCP shard files, got $SHARD_COUNT"
+    exit 1
+fi
+echo "  OK: $SHARD_COUNT DCP shard files"
+
+# Check metadata content
+CKPT_STEP=$(python -c "import torch; m=torch.load('$STEP_DIR/training_state.pt', weights_only=False); print(m['step'])")
+echo "  OK: Checkpoint at step $CKPT_STEP"
+
+echo ""
+echo "=== Phase 3: Resume from checkpoint ==="
+CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun --nnodes=1 --nproc-per-node=4 \
+    -m mini_trainer.train \
+    --model-name-or-path "$MODEL" \
+    --data-path "$DATA" \
+    --batch-size 2 \
+    --max-tokens-per-gpu 512 \
+    --learning-rate 1e-4 \
+    --output-dir "$OUTPUT_DIR/resumed" \
+    --training-mode step \
+    --max-steps 50 \
+    --osft \
+    --osft-unfreeze-rank-ratio 0.2 \
+    --resume-from-full-state-checkpoint "$STEP_DIR" \
+    > "$OUTPUT_DIR/resume.log" 2>&1
+
+RESUME_EXIT=$?
+if [ $RESUME_EXIT -ne 0 ]; then
+    echo "FAIL: Resume training exited with code $RESUME_EXIT"
+    grep "Error\|Traceback" "$OUTPUT_DIR/resume.log" | head -5
+    exit 1
+fi
+
+# Check that training continued from the checkpoint step
+RESUMED_STEPS=$(grep '"step"' "$OUTPUT_DIR/resume.log" | wc -l)
+FIRST_RESUMED_STEP=$(grep '"step"' "$OUTPUT_DIR/resume.log" | head -1 | grep -o '[0-9]*' | tail -1)
+echo "  Resumed training ran $RESUMED_STEPS steps, starting from step $FIRST_RESUMED_STEP"
+
+if [ "$FIRST_RESUMED_STEP" -le "$CKPT_STEP" ]; then
+    echo "FAIL: First resumed step ($FIRST_RESUMED_STEP) should be > checkpoint step ($CKPT_STEP)"
+    exit 1
+fi
+
+echo ""
+echo "========================================"
+echo "SIGNAL TEST PASSED"
+echo "  Checkpoint saved at step $CKPT_STEP"
+echo "  Resumed from step $FIRST_RESUMED_STEP"
+echo "  Training completed $RESUMED_STEPS more steps"
+echo "========================================"

--- a/regression_tests/test_full_state_checkpoint_signal.sh
+++ b/regression_tests/test_full_state_checkpoint_signal.sh
@@ -75,8 +75,8 @@ echo "Waiting for training to checkpoint and exit..."
 EXITED=false
 for i in $(seq 1 120); do
     if ! kill -0 "$TRAIN_PID" 2>/dev/null; then
-        wait "$TRAIN_PID" 2>/dev/null
-        EXIT_CODE=$?
+        EXIT_CODE=0
+        wait "$TRAIN_PID" 2>/dev/null || EXIT_CODE=$?
         echo "Training exited with code: $EXIT_CODE"
         EXITED=true
         break

--- a/regression_tests/test_full_state_checkpoint_signal.sh
+++ b/regression_tests/test_full_state_checkpoint_signal.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 
 MODEL="${1:-/tmp/tiny_qwen2}"
 DATA="${2:-/tmp/tiny_test.jsonl}"
-OUTPUT_DIR="/mnt/nvme3n1/workspace/osilkin/pr-repos/async-checkpointing/mini_trainer/signal_test_output"
+OUTPUT_DIR="${3:-/tmp/signal_test_output}"
 TRIGGER_FILE="/dev/shm/mini_trainer_checkpoint_trigger"
 
 rm -rf "$OUTPUT_DIR"

--- a/regression_tests/test_full_state_checkpoint_signal.sh
+++ b/regression_tests/test_full_state_checkpoint_signal.sh
@@ -42,7 +42,7 @@ echo "Training PID: $TRAIN_PID"
 echo "Waiting for training to start..."
 STARTED=false
 for i in $(seq 1 180); do
-    METRICS_FILE=$(ls "$OUTPUT_DIR"/training_metrics_*.jsonl 2>/dev/null | head -1)
+    METRICS_FILE=$(find "$OUTPUT_DIR" -maxdepth 1 -name 'training_metrics_*.jsonl' -print -quit 2>/dev/null)
     if [ -n "$METRICS_FILE" ]; then
         LINES=$(wc -l < "$METRICS_FILE")
         if [ "$LINES" -ge 5 ]; then
@@ -167,8 +167,8 @@ if [ $RESUME_EXIT -ne 0 ]; then
 fi
 
 # Check that training continued from the checkpoint step
-RESUMED_STEPS=$(grep '"step"' "$OUTPUT_DIR/resume.log" | wc -l)
-FIRST_RESUMED_STEP=$(grep '"step"' "$OUTPUT_DIR/resume.log" | head -1 | grep -o '[0-9]*' | tail -1)
+RESUMED_STEPS=$(grep -c '"step":' "$OUTPUT_DIR/resume.log" || echo 0)
+FIRST_RESUMED_STEP=$(grep '"step":' "$OUTPUT_DIR/resume.log" | head -1 | python -c "import sys,re; print(re.search(r'\"step\":\s*(\d+)', sys.stdin.read()).group(1))" 2>/dev/null || echo 0)
 echo "  Resumed training ran $RESUMED_STEPS steps, starting from step $FIRST_RESUMED_STEP"
 
 if [ "$FIRST_RESUMED_STEP" -le "$CKPT_STEP" ]; then

--- a/regression_tests/test_full_state_checkpoint_signal.sh
+++ b/regression_tests/test_full_state_checkpoint_signal.sh
@@ -144,6 +144,7 @@ echo "  OK: Checkpoint at step $CKPT_STEP"
 
 echo ""
 echo "=== Phase 3: Resume from checkpoint ==="
+RESUME_EXIT=0
 CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun --nnodes=1 --nproc-per-node=4 \
     -m mini_trainer.train \
     --model-name-or-path "$MODEL" \
@@ -157,9 +158,7 @@ CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun --nnodes=1 --nproc-per-node=4 \
     --osft \
     --osft-unfreeze-rank-ratio 0.2 \
     --resume-from-full-state-checkpoint "$STEP_DIR" \
-    > "$OUTPUT_DIR/resume.log" 2>&1
-
-RESUME_EXIT=$?
+    > "$OUTPUT_DIR/resume.log" 2>&1 || RESUME_EXIT=$?
 if [ $RESUME_EXIT -ne 0 ]; then
     echo "FAIL: Resume training exited with code $RESUME_EXIT"
     grep "Error\|Traceback" "$OUTPUT_DIR/resume.log" | head -5

--- a/src/mini_trainer/api_train.py
+++ b/src/mini_trainer/api_train.py
@@ -216,6 +216,21 @@ def run_training(torch_args: TorchrunArgs, train_args: TrainingArgs) -> None:
 
     logger.info("Running training command as subprocess: %s", " ".join(command))
 
+    # Install parent-side signal handler for on-demand checkpointing.
+    # When a signal arrives, we write the trigger file and give workers
+    # generous time to save a checkpoint before proceeding with shutdown.
+    signal_handler = None
+    if train_args.on_demand_checkpointing:
+        from mini_trainer.full_state_checkpoint import FullStateCheckpointer
+
+        signal_handler = FullStateCheckpointer(
+            checkpoint_dir=str(output_path / "full_state_checkpoints"),
+            rank=0,
+            world_size=1,
+        )
+        signal_handler.install_signal_handlers()
+        logger.info("On-demand checkpointing: parent signal handlers installed")
+
     # Run the training process
     log_file = output_path / f"training_log_node{torch_args.node_rank}.log"
     process = None
@@ -235,21 +250,48 @@ def run_training(torch_args: TorchrunArgs, train_args: TrainingArgs) -> None:
         interrupt = e
     finally:
         if process is None:
+            if signal_handler is not None:
+                signal_handler.cleanup()
             return
 
-        failure = process.poll() != 0
-        if not failure:
-            logger.info("Training completed successfully! 🎉")
-        else:
-            logger.error("Training subprocess failed. Check logs for details.")
+        # If on-demand checkpointing caught a signal, give workers time
+        # to detect the trigger and save before we send our own signals.
+        if signal_handler is not None and signal_handler._trigger_path.exists():
+            logger.info(
+                "On-demand checkpoint: signal received. Waiting up to 300s "
+                "for workers to save checkpoint before shutdown..."
+            )
+            try:
+                process.wait(timeout=300)
+            except subprocess.TimeoutExpired:
+                logger.warning("On-demand checkpoint: workers did not finish within 300s. Proceeding with shutdown.")
 
-        process.terminate()
+        # Check final exit status
         try:
-            logger.info("Waiting for process to exit (60s timeout)...")
             process.wait(timeout=60)
         except subprocess.TimeoutExpired:
-            logger.error("Training subprocess did not terminate, sending SIGKILL.")
-            process.kill()
+            pass
+        process_code = process.poll()
+
+        if process_code is not None and process_code == 0:
+            logger.info("Training completed successfully! 🎉")
+        elif process_code is None:
+            logger.error("Training subprocess has not exited. Sending SIGTERM.")
+            process.terminate()
+            try:
+                process.wait(timeout=60)
+            except subprocess.TimeoutExpired:
+                logger.error("Training subprocess did not terminate, sending SIGKILL.")
+                process.kill()
+        else:
+            logger.error("Training subprocess exited with code %d.", process_code)
+
+        # Recompute after any forced shutdown
+        process_code = process.poll()
+        failure = process_code is None or process_code != 0
+
+        if signal_handler is not None:
+            signal_handler.cleanup()
 
         if interrupt:
             raise interrupt

--- a/src/mini_trainer/api_train.py
+++ b/src/mini_trainer/api_train.py
@@ -208,6 +208,12 @@ def run_training(torch_args: TorchrunArgs, train_args: TrainingArgs) -> None:
     if train_args.trust_remote_code:
         command.append("--trust-remote-code")
 
+    if train_args.on_demand_checkpointing:
+        command.append("--on-demand-checkpointing")
+
+    if train_args.resume_from_full_state_checkpoint:
+        command.append(f"--resume-from-full-state-checkpoint={train_args.resume_from_full_state_checkpoint}")
+
     logger.info("Running training command as subprocess: %s", " ".join(command))
 
     # Run the training process

--- a/src/mini_trainer/full_state_checkpoint.py
+++ b/src/mini_trainer/full_state_checkpoint.py
@@ -21,9 +21,7 @@ import torch.distributed as dist
 import torch.distributed.checkpoint as dcp
 from torch.distributed.checkpoint.state_dict import (
     get_model_state_dict,
-    get_optimizer_state_dict,
     set_model_state_dict,
-    set_optimizer_state_dict,
 )
 
 logger = logging.getLogger(__name__)
@@ -145,8 +143,11 @@ class FullStateCheckpointer:
         logger.info("Rank %d: saving full-state checkpoint to %s", self._rank, save_dir)
 
         # 1. Save model + optimizer state via DCP (sharded, all ranks participate)
+        # We use optimizer.state_dict() directly instead of get_optimizer_state_dict()
+        # because the latter fails with FSDP2 when the optimizer was created with only
+        # trainable parameters (KeyError on parameter ID mapping).
         model_state = get_model_state_dict(model)
-        optim_state = get_optimizer_state_dict(model, optimizer)
+        optim_state = optimizer.state_dict()
         dcp.save(
             {"model": model_state, "optimizer": optim_state},
             checkpoint_id=str(save_dir / "distributed"),
@@ -253,10 +254,10 @@ class FullStateCheckpointer:
         dcp_dir = str(checkpoint_dir / "distributed")
 
         model_state = get_model_state_dict(model)
-        optim_state = get_optimizer_state_dict(model, optimizer)
+        optim_state = optimizer.state_dict()
         dcp.load(
             {"model": model_state, "optimizer": optim_state},
             checkpoint_id=dcp_dir,
         )
         set_model_state_dict(model, model_state)
-        set_optimizer_state_dict(model, optimizer, optim_state)
+        optimizer.load_state_dict(optim_state)

--- a/src/mini_trainer/full_state_checkpoint.py
+++ b/src/mini_trainer/full_state_checkpoint.py
@@ -1,0 +1,258 @@
+"""
+Full-state on-demand checkpointing for training resumption.
+
+Saves complete training state (model, optimizer, scheduler, RNG) via DCP
+sharded saves when a termination signal is received. Each rank saves its
+own shard — no gathering to rank 0.
+
+Trigger mechanism: signal handler writes a file to /dev/shm (or configurable
+path). Workers poll this file at batch boundaries and coordinate via
+all_reduce(MAX) to ensure all ranks agree.
+"""
+
+import logging
+import random
+import signal
+from pathlib import Path
+
+import numpy as np
+import torch
+import torch.distributed as dist
+import torch.distributed.checkpoint as dcp
+from torch.distributed.checkpoint.state_dict import (
+    get_model_state_dict,
+    get_optimizer_state_dict,
+    set_model_state_dict,
+    set_optimizer_state_dict,
+)
+
+logger = logging.getLogger(__name__)
+
+# Signals that indicate the training process should checkpoint and exit.
+# Covers: Kubernetes (SIGTERM), SLURM (SIGUSR1/2), LSF (SIGXCPU, SIGQUIT),
+# interactive (SIGINT), terminal disconnect (SIGHUP).
+_CHECKPOINT_SIGNALS = (
+    signal.SIGTERM,
+    signal.SIGINT,
+    signal.SIGUSR1,
+    signal.SIGUSR2,
+    signal.SIGXCPU,
+    signal.SIGHUP,
+    signal.SIGQUIT,
+)
+
+_DEFAULT_TRIGGER_PATH = "/dev/shm/mini_trainer_checkpoint_trigger"
+
+
+class FullStateCheckpointer:
+    """Manages signal-driven full-state checkpointing for distributed training.
+
+    On receiving a termination signal, writes a trigger file. At batch
+    boundaries, workers poll this file and coordinate via all_reduce(MAX)
+    to save a sharded DCP checkpoint before exiting.
+    """
+
+    def __init__(
+        self,
+        checkpoint_dir: str,
+        rank: int,
+        world_size: int,
+        trigger_path: str = _DEFAULT_TRIGGER_PATH,
+    ):
+        self._checkpoint_dir = Path(checkpoint_dir)
+        self._rank = rank
+        self._world_size = world_size
+        self._trigger_path = Path(trigger_path)
+        self._original_handlers: dict[signal.Signals, signal._HANDLER] = {}
+
+    def install_signal_handlers(self):
+        """Register signal handlers that write the trigger file on receipt."""
+        for sig in _CHECKPOINT_SIGNALS:
+            try:
+                self._original_handlers[sig] = signal.getsignal(sig)
+                signal.signal(sig, self._handle_signal)
+            except (OSError, ValueError):
+                # Some signals may not be settable (e.g., in non-main thread)
+                pass
+
+    def _handle_signal(self, signum, frame):
+        """Write trigger file atomically on signal receipt."""
+        try:
+            self._trigger_path.touch()
+        except OSError:
+            pass
+
+    def should_save(self, device: torch.device) -> bool:
+        """Check if a checkpoint save has been triggered.
+
+        Polls the trigger file locally, then coordinates with all ranks
+        via all_reduce(MAX) so all ranks agree.
+
+        Args:
+            device: The device to use for the all_reduce tensor.
+
+        Returns:
+            True if any rank detected the trigger.
+        """
+        local_triggered = self._trigger_path.exists()
+        if dist.is_initialized():
+            trigger_tensor = torch.tensor(
+                int(local_triggered), dtype=torch.int32, device=device
+            )
+            dist.all_reduce(trigger_tensor, op=dist.ReduceOp.MAX)
+            return trigger_tensor.item() > 0
+        return local_triggered
+
+    def cleanup(self):
+        """Remove the trigger file if it exists."""
+        self._trigger_path.unlink(missing_ok=True)
+
+    def save(
+        self,
+        model: torch.nn.Module,
+        optimizer: torch.optim.Optimizer,
+        lr_scheduler: torch.optim.lr_scheduler.LRScheduler,
+        training_state: dict,
+        checkpointer_state: dict,
+        data_loader: torch.utils.data.DataLoader,
+        device: torch.device,
+    ):
+        """Save complete training state for exact resumption.
+
+        Model and optimizer state are saved sharded via DCP (each rank saves
+        its own shard). RNG states are saved per-rank. Training metadata is
+        saved by rank 0 only.
+
+        Args:
+            model: The FSDP2-wrapped model.
+            optimizer: The optimizer (with OSFT wrapping if applicable).
+            lr_scheduler: The learning rate scheduler.
+            training_state: Dict with step, epoch, total_samples_accumulated,
+                total_tokens_processed, last_validation_loss.
+            checkpointer_state: Dict with last_saved_samples,
+                last_frequency_saved_samples, best_val_loss.
+            data_loader: The training data loader (for sampler state).
+            device: The device for distributed operations.
+        """
+        step = training_state["step"]
+        save_dir = self._checkpoint_dir / f"step_{step}"
+        save_dir.mkdir(parents=True, exist_ok=True)
+
+        logger.info("Rank %d: saving full-state checkpoint to %s", self._rank, save_dir)
+
+        # 1. Save model + optimizer state via DCP (sharded, all ranks participate)
+        model_state = get_model_state_dict(model)
+        optim_state = get_optimizer_state_dict(model, optimizer)
+        dcp.save(
+            {"model": model_state, "optimizer": optim_state},
+            checkpoint_id=str(save_dir / "distributed"),
+        )
+
+        # 2. Save per-rank RNG states
+        self._save_rng_states(save_dir)
+
+        # 3. Save global metadata (rank 0 only)
+        sampler_epoch = getattr(data_loader.sampler, "_epoch", 0)
+        if self._rank == 0:
+            self._save_metadata(
+                save_dir=save_dir,
+                training_state=training_state,
+                checkpointer_state=checkpointer_state,
+                lr_scheduler_state=lr_scheduler.state_dict(),
+                sampler_epoch=sampler_epoch,
+            )
+
+        if dist.is_initialized():
+            dist.barrier()
+        logger.info("Rank %d: full-state checkpoint saved successfully", self._rank)
+
+    def _save_metadata(
+        self,
+        save_dir: Path,
+        training_state: dict,
+        checkpointer_state: dict,
+        lr_scheduler_state: dict,
+        sampler_epoch: int,
+    ):
+        """Save training metadata (rank 0 only)."""
+        metadata = {
+            **training_state,
+            "checkpointer_state": checkpointer_state,
+            "lr_scheduler_state": lr_scheduler_state,
+            "sampler_epoch": sampler_epoch,
+        }
+        torch.save(metadata, save_dir / "training_state.pt")
+
+    def _save_rng_states(self, save_dir: Path):
+        """Save per-rank RNG states for exact reproducibility."""
+        rng_state = {
+            "torch_rng": torch.get_rng_state(),
+            "python_rng": random.getstate(),
+            "numpy_rng": np.random.get_state(),
+        }
+        # CUDA RNG state is only available if CUDA is initialized
+        if torch.cuda.is_available() and torch.cuda.is_initialized():
+            rng_state["cuda_rng"] = torch.cuda.get_rng_state()
+        torch.save(rng_state, save_dir / f"rng_state_rank_{self._rank}.pt")
+
+    @staticmethod
+    def load_metadata(checkpoint_dir: str | Path) -> dict:
+        """Load training metadata from a checkpoint directory.
+
+        Args:
+            checkpoint_dir: Path to the checkpoint directory (e.g., step_10/).
+
+        Returns:
+            Dict containing training_state, checkpointer_state,
+            lr_scheduler_state, sampler_epoch.
+        """
+        checkpoint_dir = Path(checkpoint_dir)
+        meta_path = checkpoint_dir / "training_state.pt"
+        if not meta_path.exists():
+            raise FileNotFoundError(f"No training_state.pt found in {checkpoint_dir}")
+        return torch.load(meta_path, weights_only=False)
+
+    @staticmethod
+    def load_rng_states(checkpoint_dir: str | Path, rank: int):
+        """Restore per-rank RNG states from a checkpoint.
+
+        Args:
+            checkpoint_dir: Path to the checkpoint directory.
+            rank: The rank whose RNG state to load.
+        """
+        checkpoint_dir = Path(checkpoint_dir)
+        rng_path = checkpoint_dir / f"rng_state_rank_{rank}.pt"
+        if not rng_path.exists():
+            raise FileNotFoundError(f"No rng_state_rank_{rank}.pt found in {checkpoint_dir}")
+
+        rng_state = torch.load(rng_path, weights_only=False)
+        torch.set_rng_state(rng_state["torch_rng"])
+        random.setstate(rng_state["python_rng"])
+        np.random.set_state(rng_state["numpy_rng"])
+        if "cuda_rng" in rng_state and torch.cuda.is_available():
+            torch.cuda.set_rng_state(rng_state["cuda_rng"])
+
+    @staticmethod
+    def load_distributed_state(
+        checkpoint_dir: str | Path,
+        model: torch.nn.Module,
+        optimizer: torch.optim.Optimizer,
+    ):
+        """Load sharded model and optimizer state from DCP checkpoint.
+
+        Args:
+            checkpoint_dir: Path to the checkpoint directory.
+            model: The FSDP2-wrapped model (must have same structure as saved).
+            optimizer: The optimizer (must match model parameters).
+        """
+        checkpoint_dir = Path(checkpoint_dir)
+        dcp_dir = str(checkpoint_dir / "distributed")
+
+        model_state = get_model_state_dict(model)
+        optim_state = get_optimizer_state_dict(model, optimizer)
+        dcp.load(
+            {"model": model_state, "optimizer": optim_state},
+            checkpoint_id=dcp_dir,
+        )
+        set_model_state_dict(model, model_state)
+        set_optimizer_state_dict(model, optimizer, optim_state)

--- a/src/mini_trainer/full_state_checkpoint.py
+++ b/src/mini_trainer/full_state_checkpoint.py
@@ -96,8 +96,15 @@ class FullStateCheckpointer:
         if dist.is_initialized():
             trigger_tensor = torch.tensor(int(local_triggered), dtype=torch.int32, device=device)
             dist.all_reduce(trigger_tensor, op=dist.ReduceOp.MAX)
-            return trigger_tensor.item() > 0
-        return local_triggered
+            should_save = trigger_tensor.item() > 0
+        else:
+            should_save = local_triggered
+
+        # Clear trigger file immediately to prevent stale triggers
+        # across restarts or subsequent should_save() calls.
+        if should_save:
+            self._trigger_path.unlink(missing_ok=True)
+        return should_save
 
     def cleanup(self):
         """Remove the trigger file and restore original signal handlers."""

--- a/src/mini_trainer/full_state_checkpoint.py
+++ b/src/mini_trainer/full_state_checkpoint.py
@@ -102,8 +102,14 @@ class FullStateCheckpointer:
         return local_triggered
 
     def cleanup(self):
-        """Remove the trigger file if it exists."""
+        """Remove the trigger file and restore original signal handlers."""
         self._trigger_path.unlink(missing_ok=True)
+        for sig, handler in self._original_handlers.items():
+            try:
+                signal.signal(sig, handler)
+            except (OSError, ValueError):
+                pass
+        self._original_handlers.clear()
 
     def save(
         self,
@@ -150,7 +156,7 @@ class FullStateCheckpointer:
         self._save_rng_states(save_dir)
 
         # 3. Save global metadata (rank 0 only)
-        sampler_epoch = getattr(data_loader.sampler, "_epoch", 0)
+        sampler_epoch = data_loader.sampler.epoch
         if self._rank == 0:
             self._save_metadata(
                 save_dir=save_dir,

--- a/src/mini_trainer/full_state_checkpoint.py
+++ b/src/mini_trainer/full_state_checkpoint.py
@@ -96,9 +96,7 @@ class FullStateCheckpointer:
         """
         local_triggered = self._trigger_path.exists()
         if dist.is_initialized():
-            trigger_tensor = torch.tensor(
-                int(local_triggered), dtype=torch.int32, device=device
-            )
+            trigger_tensor = torch.tensor(int(local_triggered), dtype=torch.int32, device=device)
             dist.all_reduce(trigger_tensor, op=dist.ReduceOp.MAX)
             return trigger_tensor.item() > 0
         return local_triggered

--- a/src/mini_trainer/full_state_checkpoint.py
+++ b/src/mini_trainer/full_state_checkpoint.py
@@ -125,6 +125,7 @@ class FullStateCheckpointer:
         checkpointer_state: dict,
         data_loader: torch.utils.data.DataLoader,
         device: torch.device,
+        rng_snapshot: dict | None = None,
     ):
         """Save complete training state for exact resumption.
 
@@ -142,6 +143,9 @@ class FullStateCheckpointer:
                 last_frequency_saved_samples, best_val_loss.
             data_loader: The training data loader (for sampler state).
             device: The device for distributed operations.
+            rng_snapshot: Pre-captured RNG state from the start of the current
+                training step. If None, captures the current RNG state (which
+                may be mid-step and incorrect for replay).
         """
         step = training_state["step"]
         save_dir = self._checkpoint_dir / f"step_{step}"
@@ -149,19 +153,25 @@ class FullStateCheckpointer:
 
         logger.info("Rank %d: saving full-state checkpoint to %s", self._rank, save_dir)
 
-        # 1. Save model + optimizer state via DCP (sharded, all ranks participate)
-        # We use optimizer.state_dict() directly instead of get_optimizer_state_dict()
-        # because the latter fails with FSDP2 when the optimizer was created with only
-        # trainable parameters (KeyError on parameter ID mapping).
+        # 1. Save model state via DCP (sharded, all ranks participate)
         model_state = get_model_state_dict(model)
-        optim_state = optimizer.state_dict()
         dcp.save(
-            {"model": model_state, "optimizer": optim_state},
+            {"model": model_state},
             checkpoint_id=str(save_dir / "distributed"),
         )
 
-        # 2. Save per-rank RNG states
-        self._save_rng_states(save_dir)
+        # 2. Save optimizer state per-rank via torch.save.
+        # We extract local shards from DTensors because:
+        # - DCP requires the target state_dict to already have entries, but
+        #   on resume the fresh optimizer has empty state.
+        # - Plain torch.save of DTensors doesn't preserve sharding correctly.
+        torch.save(
+            self._extract_local_optim_state(optimizer),
+            save_dir / f"optimizer_rank_{self._rank}.pt",
+        )
+
+        # 3. Save per-rank RNG states (use snapshot from step start if provided)
+        self._save_rng_states(save_dir, rng_snapshot=rng_snapshot)
 
         # 3. Save model config for architecture consistency on resume
         # The model may have been modified (e.g., vocab resize) during the first
@@ -202,8 +212,17 @@ class FullStateCheckpointer:
         }
         torch.save(metadata, save_dir / "training_state.pt")
 
-    def _save_rng_states(self, save_dir: Path):
-        """Save per-rank RNG states for exact reproducibility."""
+    def _save_rng_states(self, save_dir: Path, rng_snapshot: dict | None = None):
+        """Save per-rank RNG states for exact reproducibility.
+
+        If rng_snapshot is provided, saves that (captured at step start) instead
+        of the current live RNG state. This is critical because the checkpoint
+        may fire mid-accumulation, and resume needs to replay from step start.
+        """
+        if rng_snapshot is not None:
+            torch.save(rng_snapshot, save_dir / f"rng_state_rank_{self._rank}.pt")
+            return
+
         rng_state = {
             "torch_rng": torch.get_rng_state(),
             "python_rng": random.getstate(),
@@ -250,6 +269,70 @@ class FullStateCheckpointer:
         np.random.set_state(rng_state["numpy_rng"])
         if "cuda_rng" in rng_state and torch.cuda.is_available():
             torch.cuda.set_rng_state(rng_state["cuda_rng"])
+
+    @staticmethod
+    def _extract_local_optim_state(optimizer):
+        """Extract optimizer state with DTensors converted to local CPU shards."""
+        from torch.distributed._tensor import DTensor
+
+        sd = optimizer.state_dict()
+        local_sd = {"state": {}, "param_groups": sd["param_groups"]}
+        for key, state in sd["state"].items():
+            local_state = {}
+            for skey, val in state.items():
+                if isinstance(val, DTensor):
+                    local_state[skey] = val._local_tensor.clone().cpu()
+                elif isinstance(val, torch.Tensor):
+                    local_state[skey] = val.clone().cpu()
+                else:
+                    local_state[skey] = val
+            local_sd["state"][key] = local_state
+        return local_sd
+
+    @staticmethod
+    def load_optimizer_state(
+        checkpoint_dir: str | Path,
+        optimizer: torch.optim.Optimizer,
+        rank: int,
+    ):
+        """Load per-rank optimizer state, reconstructing DTensors from local shards.
+
+        Requires the optimizer to already have state entries (do a dummy step first
+        if the optimizer is fresh).
+
+        Args:
+            checkpoint_dir: Path to the checkpoint directory.
+            optimizer: The optimizer to load state into.
+            rank: The rank whose optimizer state to load.
+        """
+        from torch.distributed._tensor import DTensor
+
+        checkpoint_dir = Path(checkpoint_dir)
+        optim_path = checkpoint_dir / f"optimizer_rank_{rank}.pt"
+        loaded_sd = torch.load(optim_path, weights_only=False)
+
+        current_sd = optimizer.state_dict()
+        for key, state in loaded_sd["state"].items():
+            if key not in current_sd["state"]:
+                current_sd["state"][key] = {}
+            for skey, val in state.items():
+                cur = current_sd["state"].get(key, {}).get(skey)
+                if cur is not None and isinstance(cur, DTensor):
+                    # Reconstruct DTensor from saved local shard
+                    new_local = val.to(cur._local_tensor.device)
+                    current_sd["state"][key][skey] = DTensor.from_local(
+                        new_local,
+                        device_mesh=cur.device_mesh,
+                        placements=cur.placements,
+                        run_check=False,
+                        shape=cur.shape,
+                        stride=cur.stride(),
+                    )
+                elif isinstance(val, torch.Tensor):
+                    current_sd["state"][key][skey] = val
+                else:
+                    current_sd["state"][key][skey] = val
+        optimizer.load_state_dict(current_sd)
 
     @staticmethod
     def load_distributed_state(

--- a/src/mini_trainer/full_state_checkpoint.py
+++ b/src/mini_trainer/full_state_checkpoint.py
@@ -156,7 +156,14 @@ class FullStateCheckpointer:
         # 2. Save per-rank RNG states
         self._save_rng_states(save_dir)
 
-        # 3. Save global metadata (rank 0 only)
+        # 3. Save model config for architecture consistency on resume
+        # The model may have been modified (e.g., vocab resize) during the first
+        # run, so we save the config to ensure resume loads the same architecture.
+        inner = getattr(model, "module", model)
+        if self._rank == 0 and hasattr(inner, "config"):
+            inner.config.save_pretrained(save_dir)
+
+        # 4. Save global metadata (rank 0 only)
         sampler_epoch = data_loader.sampler.epoch
         if self._rank == 0:
             self._save_metadata(

--- a/src/mini_trainer/full_state_checkpoint.py
+++ b/src/mini_trainer/full_state_checkpoint.py
@@ -311,28 +311,27 @@ class FullStateCheckpointer:
         optim_path = checkpoint_dir / f"optimizer_rank_{rank}.pt"
         loaded_sd = torch.load(optim_path, weights_only=False)
 
-        current_sd = optimizer.state_dict()
-        for key, state in loaded_sd["state"].items():
-            if key not in current_sd["state"]:
-                current_sd["state"][key] = {}
+        # Write loaded state directly into optimizer.state, bypassing
+        # load_state_dict which may deep-copy and alter DTensor values.
+        # The optimizer.state uses parameter objects as keys; we iterate
+        # param_groups to get the correct param-to-index mapping.
+        param_list = [p for group in optimizer.param_groups for p in group["params"]]
+        for idx_str, state in loaded_sd["state"].items():
+            idx = int(idx_str) if isinstance(idx_str, str) else idx_str
+            if idx >= len(param_list):
+                continue
+            param = param_list[idx]
+            if param not in optimizer.state:
+                optimizer.state[param] = {}
             for skey, val in state.items():
-                cur = current_sd["state"].get(key, {}).get(skey)
+                cur = optimizer.state[param].get(skey)
                 if cur is not None and isinstance(cur, DTensor):
-                    # Reconstruct DTensor from saved local shard
-                    new_local = val.to(cur._local_tensor.device)
-                    current_sd["state"][key][skey] = DTensor.from_local(
-                        new_local,
-                        device_mesh=cur.device_mesh,
-                        placements=cur.placements,
-                        run_check=False,
-                        shape=cur.shape,
-                        stride=cur.stride(),
-                    )
+                    # Copy loaded local shard into existing DTensor's storage
+                    cur._local_tensor.copy_(val.to(cur._local_tensor.device))
                 elif isinstance(val, torch.Tensor):
-                    current_sd["state"][key][skey] = val
+                    optimizer.state[param][skey] = val.to(param.device)
                 else:
-                    current_sd["state"][key][skey] = val
-        optimizer.load_state_dict(current_sd)
+                    optimizer.state[param][skey] = val
 
     @staticmethod
     def load_distributed_state(

--- a/src/mini_trainer/setup_model_for_training.py
+++ b/src/mini_trainer/setup_model_for_training.py
@@ -3,12 +3,14 @@ import inspect
 import math
 import os
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 import torch
 import torch.distributed as dist
+import torch.distributed.checkpoint as dcp
 from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import checkpoint_wrapper as ptd_checkpoint_wrapper
-from torch.distributed.checkpoint.state_dict import StateDictOptions, set_model_state_dict
+from torch.distributed.checkpoint.state_dict import StateDictOptions, get_model_state_dict, set_model_state_dict
 from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.fsdp import MixedPrecisionPolicy, fully_shard
 from transformers import AutoConfig, AutoTokenizer, Mxfp4Config
@@ -113,6 +115,7 @@ class ModelInitializationContext:
     is_osft: bool = False
     state_dict: dict[str, torch.Tensor] | None = None
     train_dtype: torch.dtype | None = None
+    resume_from_checkpoint: str | None = None
 
 
 def _sanitize_meta_attribute_aliases(model: torch.nn.Module) -> int:
@@ -571,15 +574,32 @@ def finalize_model_initialization(model: torch.nn.Module, context: ModelInitiali
         _require_distributed_initialized("OSFT finalization")
         log_rank_0("🔄 [Phase 3] Finalizing OSFT initialization")
 
-        # Step 1: Synchronize non-OSFT parameters across ranks
-        log_rank_0("🔄 [OSFT] Distributing non-OSFT parameters")
-        model.post_fsdp2_wrap_synchronize_state_dict_across_procs(model, context.state_dict)
-        log_rank_0("   ✓ Non-OSFT parameters distributed")
+        if context.resume_from_checkpoint:
+            # Resume path: load from DCP checkpoint instead of computing SVD
+            log_rank_0("🔄 [OSFT] Loading model state from full-state checkpoint (skipping SVD)")
+            # Synchronize non-OSFT parameters so model structure is correct before DCP load
+            model.post_fsdp2_wrap_synchronize_state_dict_across_procs(model, context.state_dict)
+            log_rank_0("   ✓ Non-OSFT parameters distributed")
 
-        # Step 2: Compute distributed SVD and distribute OSFT parameters
-        log_rank_0("🔄 [OSFT] Computing distributed SVD for OSFT parameters")
-        model.compute_distributed_svd(model, context.state_dict)
-        log_rank_0("   ✓ OSFT parameters computed and distributed")
+            # DCP load overwrites all parameters (OSFT and non-OSFT) with checkpoint values
+            log_rank_0("🔄 [OSFT] Loading distributed checkpoint")
+            checkpoint_dir = Path(context.resume_from_checkpoint)
+            dcp_dir = str(checkpoint_dir / "distributed")
+            model_state = get_model_state_dict(model)
+            dcp.load({"model": model_state}, checkpoint_id=dcp_dir)
+            set_model_state_dict(model, model_state)
+            log_rank_0("   ✓ Model state loaded from checkpoint")
+        else:
+            # Normal path: compute distributed SVD
+            # Step 1: Synchronize non-OSFT parameters across ranks
+            log_rank_0("🔄 [OSFT] Distributing non-OSFT parameters")
+            model.post_fsdp2_wrap_synchronize_state_dict_across_procs(model, context.state_dict)
+            log_rank_0("   ✓ Non-OSFT parameters distributed")
+
+            # Step 2: Compute distributed SVD and distribute OSFT parameters
+            log_rank_0("🔄 [OSFT] Computing distributed SVD for OSFT parameters")
+            model.compute_distributed_svd(model, context.state_dict)
+            log_rank_0("   ✓ OSFT parameters computed and distributed")
 
         # Mark OSFT initialization as complete
         model.mark_fsdp2_initialized()
@@ -1237,6 +1257,7 @@ def setup_training_components(
     beta2: float = 0.95,
     eps: float = 1e-8,
     weight_decay: float = 0.0,
+    resume_from_checkpoint: str | None = None,
 ) -> tuple[torch.nn.Module, torch.optim.Optimizer, torch.optim.lr_scheduler.LRScheduler]:
     """
     Set up training components including model wrapping, optimizer, and learning rate scheduler.
@@ -1265,6 +1286,7 @@ def setup_training_components(
 
     # Phase 1: Prepare model for FSDP2 wrapping
     init_context = prepare_model_for_fsdp2(model)
+    init_context.resume_from_checkpoint = resume_from_checkpoint
 
     # Phase 2: Pure FSDP2 wrapping
     model = wrap_fsdp2(model)

--- a/src/mini_trainer/setup_model_for_training.py
+++ b/src/mini_trainer/setup_model_for_training.py
@@ -575,52 +575,25 @@ def finalize_model_initialization(model: torch.nn.Module, context: ModelInitiali
         log_rank_0("🔄 [Phase 3] Finalizing OSFT initialization")
 
         if context.resume_from_checkpoint:
-            # Resume path: materialize meta DTensors without SVD, then load from DCP.
-            log_rank_0("🔄 [OSFT] Resuming from checkpoint (skipping SVD)")
+            # Resume path: use normal SVD initialization to materialize meta
+            # tensors with correct FSDP2 tracking, then overwrite values from
+            # checkpoint. We MUST use SVD for materialization because replacing
+            # DTensor objects breaks FSDP2's FSDPParam references and mixed
+            # precision (reduce_dtype/param_dtype) tracking.
+            log_rank_0("🔄 [OSFT] Materializing via SVD, then loading checkpoint")
 
-            # The original HF state dict is not needed on resume — free it.
-            context.state_dict = None
-            gc.collect()
+            # Step 1: Normal materialization
+            log_rank_0("🔄 [OSFT] Distributing non-OSFT parameters")
+            model.post_fsdp2_wrap_synchronize_state_dict_across_procs(model, context.state_dict)
+            log_rank_0("   ✓ Non-OSFT parameters distributed")
 
-            # Step 1: Materialize all meta DTensors by replacing their local shards
-            # with zero-initialized tensors on the correct device. This preserves
-            # FSDP2's sharding metadata while moving params off meta device.
-            from torch.distributed._tensor import DTensor
+            log_rank_0("🔄 [OSFT] Computing SVD for materialization")
+            model.compute_distributed_svd(model, context.state_dict)
+            log_rank_0("   ✓ Parameters materialized")
 
-            # Use local CUDA device (not global rank, which breaks on multi-node)
-            device = torch.device("cuda", torch.cuda.current_device())
-            materialized = 0
-
-            def _materialize_dtensor(dt, device):
-                """Create a zero-filled DTensor preserving the original global shape."""
-                new_local = torch.zeros_like(dt._local_tensor, device=device)
-                # Preserve the original global shape (not local * world_size which may over-count
-                # due to FSDP2 padding the last shard).
-                return DTensor.from_local(
-                    new_local,
-                    device_mesh=dt.device_mesh,
-                    placements=dt.placements,
-                    run_check=False,
-                    shape=dt.shape,  # preserve global shape
-                    stride=dt.stride(),  # preserve global stride
-                )
-
-            for _, mod in model.named_modules():
-                for param_name, param in list(mod._parameters.items()):
-                    if param is not None and isinstance(param, DTensor) and param._local_tensor.is_meta:
-                        new_dt = _materialize_dtensor(param, device)
-                        mod._parameters[param_name] = torch.nn.Parameter(new_dt, requires_grad=param.requires_grad)
-                        materialized += 1
-                for buf_name, buf in list(mod._buffers.items()):
-                    if buf is not None and isinstance(buf, DTensor) and buf._local_tensor.is_meta:
-                        new_dt = _materialize_dtensor(buf, device)
-                        mod._buffers[buf_name] = new_dt
-                        materialized += 1
-            log_rank_0(f"   ✓ Materialized {materialized} meta DTensors")
-
-            # Step 2: Load checkpoint values via DCP in-place.
-            # Filter out keys not in the checkpoint (e.g., rotary embedding
-            # buffers like inv_freq that aren't saved but are recomputed).
+            # Step 2: Overwrite with checkpoint values via DCP in-place.
+            # model.state_dict() returns tensors sharing storage with the
+            # FSDP2-tracked parameters, so DCP writes go directly into them.
             log_rank_0("🔄 [OSFT] Loading checkpoint state via DCP")
             checkpoint_dir = Path(context.resume_from_checkpoint)
             dcp_dir = str(checkpoint_dir / "distributed")
@@ -631,63 +604,13 @@ def finalize_model_initialization(model: torch.nn.Module, context: ModelInitiali
             ckpt_keys = {k[len("model.") :] for k in ckpt_metadata.state_dict_metadata if k.startswith("model.")}
 
             sd = model.state_dict()
-            # Only load keys that exist in both the model and the checkpoint
             missing_in_ckpt = set(sd.keys()) - ckpt_keys
             if missing_in_ckpt:
-                log_rank_0(
-                    f"   Skipping {len(missing_in_ckpt)} model keys not in checkpoint (e.g., {next(iter(missing_in_ckpt))})"
-                )
+                log_rank_0(f"   Skipping {len(missing_in_ckpt)} keys not in checkpoint")
                 sd = {k: v for k, v in sd.items() if k in ckpt_keys}
 
             dcp.load({"model": sd}, checkpoint_id=dcp_dir)
             log_rank_0("   ✓ Model state loaded from checkpoint")
-
-            # Step 3: Reconcile OSFT parameter dtypes after DCP load.
-            # The gradient projection in project_gradient_to_orthogonal_space()
-            # requires U_high/V_high to be in the same dtype as the gradients
-            # (which follow the FSDP2 param dtype). DCP may have saved them in
-            # a different dtype (e.g., bfloat16 output_dtype vs float32 param_dtype).
-            expected_dtype = getattr(model, "output_dtype", None) or getattr(model, "upcast_dtype", None)
-            if expected_dtype:
-                casted = 0
-                for _, mod in model.named_modules():
-                    for buf_name, buf in list(mod._buffers.items()):
-                        if buf is not None and "osft_" in buf_name and buf.dtype != expected_dtype:
-                            if isinstance(buf, DTensor):
-                                new_local = buf._local_tensor.to(expected_dtype)
-                                mod._buffers[buf_name] = DTensor.from_local(
-                                    new_local,
-                                    device_mesh=buf.device_mesh,
-                                    placements=buf.placements,
-                                    run_check=False,
-                                    shape=buf.shape,
-                                    stride=buf.stride(),
-                                )
-                            else:
-                                mod._buffers[buf_name] = buf.to(expected_dtype)
-                            casted += 1
-                    for param_name, param in list(mod._parameters.items()):
-                        if param is not None and "osft_" in param_name and param.dtype != expected_dtype:
-                            if isinstance(param, DTensor):
-                                new_local = param._local_tensor.to(expected_dtype)
-                                new_dt = DTensor.from_local(
-                                    new_local,
-                                    device_mesh=param.device_mesh,
-                                    placements=param.placements,
-                                    run_check=False,
-                                    shape=param.shape,
-                                    stride=param.stride(),
-                                )
-                                mod._parameters[param_name] = torch.nn.Parameter(
-                                    new_dt, requires_grad=param.requires_grad
-                                )
-                            else:
-                                mod._parameters[param_name] = torch.nn.Parameter(
-                                    param.data.to(expected_dtype), requires_grad=param.requires_grad
-                                )
-                            casted += 1
-                if casted:
-                    log_rank_0(f"   Casted {casted} OSFT tensors to {expected_dtype}")
         else:
             # Normal path: compute distributed SVD
             # Step 1: Synchronize non-OSFT parameters across ranks

--- a/src/mini_trainer/setup_model_for_training.py
+++ b/src/mini_trainer/setup_model_for_training.py
@@ -575,19 +575,50 @@ def finalize_model_initialization(model: torch.nn.Module, context: ModelInitiali
         log_rank_0("🔄 [Phase 3] Finalizing OSFT initialization")
 
         if context.resume_from_checkpoint:
-            # Resume path: load from DCP checkpoint instead of computing SVD
+            # Resume path: load ALL parameters from DCP checkpoint, skipping SVD.
+            # Strategy: read full (unsharded) state dict on rank 0 from DCP,
+            # then broadcast to materialize meta tensors on all ranks.
             log_rank_0("🔄 [OSFT] Loading model state from full-state checkpoint (skipping SVD)")
-            # Synchronize non-OSFT parameters so model structure is correct before DCP load
-            model.post_fsdp2_wrap_synchronize_state_dict_across_procs(model, context.state_dict)
-            log_rank_0("   ✓ Non-OSFT parameters distributed")
-
-            # DCP load overwrites all parameters (OSFT and non-OSFT) with checkpoint values
-            log_rank_0("🔄 [OSFT] Loading distributed checkpoint")
             checkpoint_dir = Path(context.resume_from_checkpoint)
             dcp_dir = str(checkpoint_dir / "distributed")
-            model_state = get_model_state_dict(model)
-            dcp.load({"model": model_state}, checkpoint_id=dcp_dir)
-            set_model_state_dict(model, model_state)
+
+            checkpoint_state = {}
+            if dist.get_rank() == 0:
+                # Read DCP metadata to discover tensor shapes/dtypes, then load
+                from torch.distributed.checkpoint import FileSystemReader
+                reader = FileSystemReader(dcp_dir)
+                metadata = reader.read_metadata()
+
+                # Create empty tensors matching the checkpoint structure
+                for fqn, tensor_meta in metadata.state_dict_metadata.items():
+                    if not fqn.startswith("model."):
+                        continue
+                    # Strip the "model." prefix that was added during save
+                    key = fqn[len("model."):]
+                    if hasattr(tensor_meta, 'size') and hasattr(tensor_meta, 'properties'):
+                        checkpoint_state[key] = torch.empty(
+                            tensor_meta.size,
+                            dtype=tensor_meta.properties.dtype,
+                            device="cpu",
+                        )
+                    else:
+                        # Scalar/buffer metadata
+                        checkpoint_state[key] = torch.tensor(0)
+
+                # Load actual values from DCP into these tensors
+                dcp.load({"model": checkpoint_state}, checkpoint_id=dcp_dir, no_dist=True)
+                log_rank_0(f"   ✓ Loaded {len(checkpoint_state)} keys from DCP on rank 0")
+
+            # Broadcast from rank 0 to all ranks, materializing meta tensors
+            set_model_state_dict(
+                model,
+                model_state_dict=checkpoint_state,
+                options=StateDictOptions(
+                    full_state_dict=True,
+                    broadcast_from_rank0=True,
+                    strict=False,
+                ),
+            )
             log_rank_0("   ✓ Model state loaded from checkpoint")
         else:
             # Normal path: compute distributed SVD

--- a/src/mini_trainer/setup_model_for_training.py
+++ b/src/mini_trainer/setup_model_for_training.py
@@ -1015,6 +1015,15 @@ def setup_model(
         except (ImportError, AttributeError) as e:
             log_rank_0(f"Could not patch mamba kernels ({e}); GraniteMoeHybrid may use Hub kernels")
 
+    # Compatibility shim for Nemotron's remote code which imports a
+    # function that was renamed in transformers 5.x. Without this,
+    # trust_remote_code=True fails with ImportError.
+    if getattr(model_config, "model_type", None) == "nemotron_h":
+        from transformers.utils import import_utils as _iu
+
+        if not hasattr(_iu, "is_flash_attn_greater_or_equal_2_10"):
+            _iu.is_flash_attn_greater_or_equal_2_10 = lambda: _iu.is_flash_attn_greater_or_equal("2.10")
+
     # Set up quantization config for GPT-OSS models
     if is_gpt_oss:
         try:

--- a/src/mini_trainer/setup_model_for_training.py
+++ b/src/mini_trainer/setup_model_for_training.py
@@ -613,11 +613,28 @@ def finalize_model_initialization(model: torch.nn.Module, context: ModelInitiali
                         materialized += 1
             log_rank_0(f"   ✓ Materialized {materialized} meta DTensors")
 
-            # Step 2: Load checkpoint values via DCP in-place
+            # Step 2: Load checkpoint values via DCP in-place.
+            # Filter out keys not in the checkpoint (e.g., rotary embedding
+            # buffers like inv_freq that aren't saved but are recomputed).
             log_rank_0("🔄 [OSFT] Loading checkpoint state via DCP")
             checkpoint_dir = Path(context.resume_from_checkpoint)
             dcp_dir = str(checkpoint_dir / "distributed")
-            dcp.load({"model": model.state_dict()}, checkpoint_id=dcp_dir)
+            from torch.distributed.checkpoint import FileSystemReader
+
+            reader = FileSystemReader(dcp_dir)
+            ckpt_metadata = reader.read_metadata()
+            ckpt_keys = {k[len("model.") :] for k in ckpt_metadata.state_dict_metadata if k.startswith("model.")}
+
+            sd = model.state_dict()
+            # Only load keys that exist in both the model and the checkpoint
+            missing_in_ckpt = set(sd.keys()) - ckpt_keys
+            if missing_in_ckpt:
+                log_rank_0(
+                    f"   Skipping {len(missing_in_ckpt)} model keys not in checkpoint (e.g., {next(iter(missing_in_ckpt))})"
+                )
+                sd = {k: v for k, v in sd.items() if k in ckpt_keys}
+
+            dcp.load({"model": sd}, checkpoint_id=dcp_dir)
             log_rank_0("   ✓ Model state loaded from checkpoint")
         else:
             # Normal path: compute distributed SVD

--- a/src/mini_trainer/setup_model_for_training.py
+++ b/src/mini_trainer/setup_model_for_training.py
@@ -575,51 +575,28 @@ def finalize_model_initialization(model: torch.nn.Module, context: ModelInitiali
         log_rank_0("🔄 [Phase 3] Finalizing OSFT initialization")
 
         if context.resume_from_checkpoint:
-            # Resume path: load ALL parameters from DCP checkpoint, skipping SVD.
-            # Strategy: read full (unsharded) state dict on rank 0 from DCP,
-            # then broadcast to materialize meta tensors on all ranks.
-            log_rank_0("🔄 [OSFT] Loading model state from full-state checkpoint (skipping SVD)")
+            # Resume path: run normal initialization to materialize all meta tensors
+            # with correct FSDP2 sharding, then overwrite with checkpoint values.
+            log_rank_0("🔄 [OSFT] Initializing model structure, then loading checkpoint state")
+
+            # Step 1: Normal materialization (non-OSFT sync + SVD)
+            log_rank_0("🔄 [OSFT] Distributing non-OSFT parameters")
+            model.post_fsdp2_wrap_synchronize_state_dict_across_procs(model, context.state_dict)
+            log_rank_0("   ✓ Non-OSFT parameters distributed")
+
+            log_rank_0("🔄 [OSFT] Computing initial SVD (will be overwritten by checkpoint)")
+            model.compute_distributed_svd(model, context.state_dict)
+            log_rank_0("   ✓ SVD complete, model materialized")
+
+            # Step 2: Overwrite with checkpoint values via DCP sharded load.
+            # Use model.state_dict() directly to get parameter references that
+            # DCP can modify in-place, avoiding set_model_state_dict which can
+            # corrupt FSDP2's internal sharding state.
+            log_rank_0("🔄 [OSFT] Loading checkpoint state via DCP (in-place)")
             checkpoint_dir = Path(context.resume_from_checkpoint)
             dcp_dir = str(checkpoint_dir / "distributed")
-
-            checkpoint_state = {}
-            if dist.get_rank() == 0:
-                # Read DCP metadata to discover tensor shapes/dtypes, then load
-                from torch.distributed.checkpoint import FileSystemReader
-                reader = FileSystemReader(dcp_dir)
-                metadata = reader.read_metadata()
-
-                # Create empty tensors matching the checkpoint structure
-                for fqn, tensor_meta in metadata.state_dict_metadata.items():
-                    if not fqn.startswith("model."):
-                        continue
-                    # Strip the "model." prefix that was added during save
-                    key = fqn[len("model."):]
-                    if hasattr(tensor_meta, 'size') and hasattr(tensor_meta, 'properties'):
-                        checkpoint_state[key] = torch.empty(
-                            tensor_meta.size,
-                            dtype=tensor_meta.properties.dtype,
-                            device="cpu",
-                        )
-                    else:
-                        # Scalar/buffer metadata
-                        checkpoint_state[key] = torch.tensor(0)
-
-                # Load actual values from DCP into these tensors
-                dcp.load({"model": checkpoint_state}, checkpoint_id=dcp_dir, no_dist=True)
-                log_rank_0(f"   ✓ Loaded {len(checkpoint_state)} keys from DCP on rank 0")
-
-            # Broadcast from rank 0 to all ranks, materializing meta tensors
-            set_model_state_dict(
-                model,
-                model_state_dict=checkpoint_state,
-                options=StateDictOptions(
-                    full_state_dict=True,
-                    broadcast_from_rank0=True,
-                    strict=False,
-                ),
-            )
-            log_rank_0("   ✓ Model state loaded from checkpoint")
+            dcp.load({"model": model.state_dict()}, checkpoint_id=dcp_dir)
+            log_rank_0("   ✓ Model state overwritten with checkpoint values")
         else:
             # Normal path: compute distributed SVD
             # Step 1: Synchronize non-OSFT parameters across ranks

--- a/src/mini_trainer/setup_model_for_training.py
+++ b/src/mini_trainer/setup_model_for_training.py
@@ -585,27 +585,30 @@ def finalize_model_initialization(model: torch.nn.Module, context: ModelInitiali
 
             device = f"cuda:{dist.get_rank()}"
             materialized = 0
+
+            def _materialize_dtensor(dt, device):
+                """Create a zero-filled DTensor preserving the original global shape."""
+                new_local = torch.zeros_like(dt._local_tensor, device=device)
+                # Preserve the original global shape (not local * world_size which may over-count
+                # due to FSDP2 padding the last shard).
+                return DTensor.from_local(
+                    new_local,
+                    device_mesh=dt.device_mesh,
+                    placements=dt.placements,
+                    run_check=False,
+                    shape=dt.shape,  # preserve global shape
+                    stride=dt.stride(),  # preserve global stride
+                )
+
             for _, mod in model.named_modules():
                 for param_name, param in list(mod._parameters.items()):
                     if param is not None and isinstance(param, DTensor) and param._local_tensor.is_meta:
-                        new_local = torch.zeros_like(param._local_tensor, device=device)
-                        new_dt = DTensor.from_local(
-                            new_local,
-                            device_mesh=param.device_mesh,
-                            placements=param.placements,
-                            run_check=False,
-                        )
+                        new_dt = _materialize_dtensor(param, device)
                         mod._parameters[param_name] = torch.nn.Parameter(new_dt, requires_grad=param.requires_grad)
                         materialized += 1
                 for buf_name, buf in list(mod._buffers.items()):
                     if buf is not None and isinstance(buf, DTensor) and buf._local_tensor.is_meta:
-                        new_local = torch.zeros_like(buf._local_tensor, device=device)
-                        new_dt = DTensor.from_local(
-                            new_local,
-                            device_mesh=buf.device_mesh,
-                            placements=buf.placements,
-                            run_check=False,
-                        )
+                        new_dt = _materialize_dtensor(buf, device)
                         mod._buffers[buf_name] = new_dt
                         materialized += 1
             log_rank_0(f"   ✓ Materialized {materialized} meta DTensors")

--- a/src/mini_trainer/setup_model_for_training.py
+++ b/src/mini_trainer/setup_model_for_training.py
@@ -641,6 +641,53 @@ def finalize_model_initialization(model: torch.nn.Module, context: ModelInitiali
 
             dcp.load({"model": sd}, checkpoint_id=dcp_dir)
             log_rank_0("   ✓ Model state loaded from checkpoint")
+
+            # Step 3: Reconcile OSFT parameter dtypes after DCP load.
+            # The gradient projection in project_gradient_to_orthogonal_space()
+            # requires U_high/V_high to be in the same dtype as the gradients
+            # (which follow the FSDP2 param dtype). DCP may have saved them in
+            # a different dtype (e.g., bfloat16 output_dtype vs float32 param_dtype).
+            expected_dtype = getattr(model, "output_dtype", None) or getattr(model, "upcast_dtype", None)
+            if expected_dtype:
+                casted = 0
+                for _, mod in model.named_modules():
+                    for buf_name, buf in list(mod._buffers.items()):
+                        if buf is not None and "osft_" in buf_name and buf.dtype != expected_dtype:
+                            if isinstance(buf, DTensor):
+                                new_local = buf._local_tensor.to(expected_dtype)
+                                mod._buffers[buf_name] = DTensor.from_local(
+                                    new_local,
+                                    device_mesh=buf.device_mesh,
+                                    placements=buf.placements,
+                                    run_check=False,
+                                    shape=buf.shape,
+                                    stride=buf.stride(),
+                                )
+                            else:
+                                mod._buffers[buf_name] = buf.to(expected_dtype)
+                            casted += 1
+                    for param_name, param in list(mod._parameters.items()):
+                        if param is not None and "osft_" in param_name and param.dtype != expected_dtype:
+                            if isinstance(param, DTensor):
+                                new_local = param._local_tensor.to(expected_dtype)
+                                new_dt = DTensor.from_local(
+                                    new_local,
+                                    device_mesh=param.device_mesh,
+                                    placements=param.placements,
+                                    run_check=False,
+                                    shape=param.shape,
+                                    stride=param.stride(),
+                                )
+                                mod._parameters[param_name] = torch.nn.Parameter(
+                                    new_dt, requires_grad=param.requires_grad
+                                )
+                            else:
+                                mod._parameters[param_name] = torch.nn.Parameter(
+                                    param.data.to(expected_dtype), requires_grad=param.requires_grad
+                                )
+                            casted += 1
+                if casted:
+                    log_rank_0(f"   Casted {casted} OSFT tensors to {expected_dtype}")
         else:
             # Normal path: compute distributed SVD
             # Step 1: Synchronize non-OSFT parameters across ranks

--- a/src/mini_trainer/setup_model_for_training.py
+++ b/src/mini_trainer/setup_model_for_training.py
@@ -575,28 +575,47 @@ def finalize_model_initialization(model: torch.nn.Module, context: ModelInitiali
         log_rank_0("🔄 [Phase 3] Finalizing OSFT initialization")
 
         if context.resume_from_checkpoint:
-            # Resume path: run normal initialization to materialize all meta tensors
-            # with correct FSDP2 sharding, then overwrite with checkpoint values.
-            log_rank_0("🔄 [OSFT] Initializing model structure, then loading checkpoint state")
+            # Resume path: materialize meta DTensors without SVD, then load from DCP.
+            log_rank_0("🔄 [OSFT] Resuming from checkpoint (skipping SVD)")
 
-            # Step 1: Normal materialization (non-OSFT sync + SVD)
-            log_rank_0("🔄 [OSFT] Distributing non-OSFT parameters")
-            model.post_fsdp2_wrap_synchronize_state_dict_across_procs(model, context.state_dict)
-            log_rank_0("   ✓ Non-OSFT parameters distributed")
+            # Step 1: Materialize all meta DTensors by replacing their local shards
+            # with zero-initialized tensors on the correct device. This preserves
+            # FSDP2's sharding metadata while moving params off meta device.
+            from torch.distributed._tensor import DTensor
 
-            log_rank_0("🔄 [OSFT] Computing initial SVD (will be overwritten by checkpoint)")
-            model.compute_distributed_svd(model, context.state_dict)
-            log_rank_0("   ✓ SVD complete, model materialized")
+            device = f"cuda:{dist.get_rank()}"
+            materialized = 0
+            for _, mod in model.named_modules():
+                for param_name, param in list(mod._parameters.items()):
+                    if param is not None and isinstance(param, DTensor) and param._local_tensor.is_meta:
+                        new_local = torch.zeros_like(param._local_tensor, device=device)
+                        new_dt = DTensor.from_local(
+                            new_local,
+                            device_mesh=param.device_mesh,
+                            placements=param.placements,
+                            run_check=False,
+                        )
+                        mod._parameters[param_name] = torch.nn.Parameter(new_dt, requires_grad=param.requires_grad)
+                        materialized += 1
+                for buf_name, buf in list(mod._buffers.items()):
+                    if buf is not None and isinstance(buf, DTensor) and buf._local_tensor.is_meta:
+                        new_local = torch.zeros_like(buf._local_tensor, device=device)
+                        new_dt = DTensor.from_local(
+                            new_local,
+                            device_mesh=buf.device_mesh,
+                            placements=buf.placements,
+                            run_check=False,
+                        )
+                        mod._buffers[buf_name] = new_dt
+                        materialized += 1
+            log_rank_0(f"   ✓ Materialized {materialized} meta DTensors")
 
-            # Step 2: Overwrite with checkpoint values via DCP sharded load.
-            # Use model.state_dict() directly to get parameter references that
-            # DCP can modify in-place, avoiding set_model_state_dict which can
-            # corrupt FSDP2's internal sharding state.
-            log_rank_0("🔄 [OSFT] Loading checkpoint state via DCP (in-place)")
+            # Step 2: Load checkpoint values via DCP in-place
+            log_rank_0("🔄 [OSFT] Loading checkpoint state via DCP")
             checkpoint_dir = Path(context.resume_from_checkpoint)
             dcp_dir = str(checkpoint_dir / "distributed")
             dcp.load({"model": model.state_dict()}, checkpoint_id=dcp_dir)
-            log_rank_0("   ✓ Model state overwritten with checkpoint values")
+            log_rank_0("   ✓ Model state loaded from checkpoint")
         else:
             # Normal path: compute distributed SVD
             # Step 1: Synchronize non-OSFT parameters across ranks

--- a/src/mini_trainer/setup_model_for_training.py
+++ b/src/mini_trainer/setup_model_for_training.py
@@ -578,12 +578,17 @@ def finalize_model_initialization(model: torch.nn.Module, context: ModelInitiali
             # Resume path: materialize meta DTensors without SVD, then load from DCP.
             log_rank_0("🔄 [OSFT] Resuming from checkpoint (skipping SVD)")
 
+            # The original HF state dict is not needed on resume — free it.
+            context.state_dict = None
+            gc.collect()
+
             # Step 1: Materialize all meta DTensors by replacing their local shards
             # with zero-initialized tensors on the correct device. This preserves
             # FSDP2's sharding metadata while moving params off meta device.
             from torch.distributed._tensor import DTensor
 
-            device = f"cuda:{dist.get_rank()}"
+            # Use local CUDA device (not global rank, which breaks on multi-node)
+            device = torch.device("cuda", torch.cuda.current_device())
             materialized = 0
 
             def _materialize_dtensor(dt, device):

--- a/src/mini_trainer/setup_model_for_training.py
+++ b/src/mini_trainer/setup_model_for_training.py
@@ -10,7 +10,7 @@ import torch
 import torch.distributed as dist
 import torch.distributed.checkpoint as dcp
 from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import checkpoint_wrapper as ptd_checkpoint_wrapper
-from torch.distributed.checkpoint.state_dict import StateDictOptions, get_model_state_dict, set_model_state_dict
+from torch.distributed.checkpoint.state_dict import StateDictOptions, set_model_state_dict
 from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.fsdp import MixedPrecisionPolicy, fully_shard
 from transformers import AutoConfig, AutoTokenizer, Mxfp4Config

--- a/src/mini_trainer/train.py
+++ b/src/mini_trainer/train.py
@@ -803,14 +803,24 @@ def train(
         )
 
         # Load optimizer state from DCP checkpoint
-        FullStateCheckpointer.load_distributed_state(
-            resume_from_full_state_checkpoint, model, optimizer
-        )
+        # (Model state was already loaded in finalize_model_initialization)
+        log_rank_0("Loading optimizer state from DCP checkpoint...")
+        import torch.distributed.checkpoint as dcp_module
+        from torch.distributed.checkpoint.state_dict import get_optimizer_state_dict, set_optimizer_state_dict
+        checkpoint_dir = Path(resume_from_full_state_checkpoint)
+        dcp_dir = str(checkpoint_dir / "distributed")
+        optim_state = get_optimizer_state_dict(model, optimizer)
+        dcp_module.load({"optimizer": optim_state}, checkpoint_id=dcp_dir)
+        set_optimizer_state_dict(model, optimizer, optim_state)
+        log_rank_0("   ✓ Optimizer state loaded")
+        dist.barrier()
+        log_rank_0("[DEBUG] Post-resume barrier passed")
 
         log_rank_0(f"Resumed at step={step}, epoch={epoch}, samples={total_samples_accumulated}")
 
-    # Track samples for batch-skipping when resuming mid-epoch
-    _resume_target_samples = total_samples_accumulated if resume_from_full_state_checkpoint else None
+    # Track steps for batch-skipping when resuming mid-epoch.
+    # We skip by step count (not sample count) to stay consistent across ranks.
+    _resume_target_step = step if resume_from_full_state_checkpoint else None
 
     # main training loop
     while not reached_stop_condition(
@@ -826,16 +836,16 @@ def train(
         data_loader.sampler.set_epoch(epoch)
         data_loader_it = iter(data_loader)
 
-        _skipped_samples = 0
+        _skipped_steps = 0
         for batch in data_loader_it:
             # Skip already-processed batches when resuming mid-epoch
-            if _resume_target_samples is not None:
-                _skipped_samples += sum(mb["num_samples"] for mb in batch)
-                if _skipped_samples < _resume_target_samples:
+            if _resume_target_step is not None:
+                _skipped_steps += 1
+                if _skipped_steps < _resume_target_step:
                     continue
                 # Done skipping — clear the resume state
-                _resume_target_samples = None
-                log_rank_0(f"Skipped {_skipped_samples} samples to resume position")
+                log_rank_0(f"Skipped {_skipped_steps} batches to resume position (target step={_resume_target_step})")
+                _resume_target_step = None
 
             batch_start_time = time.time()
             batch_totals.reset_batch()

--- a/src/mini_trainer/train.py
+++ b/src/mini_trainer/train.py
@@ -873,7 +873,13 @@ def train(
             batch_start_time = time.time()
             batch_totals.reset_batch()
             torch.cuda.reset_peak_memory_stats()
+            _interrupted = False
             for grad_accum, mb in enumerate(batch):
+                # Check for on-demand checkpoint before forward pass
+                if full_state_checkpointer is not None and full_state_checkpointer.should_save(device):
+                    _interrupted = True
+                    break
+
                 mb_start_time = time.time()
                 mb_num_loss_counted_tokens = mb["num_loss_counted_tokens"]
                 mb_num_samples = mb["num_samples"]
@@ -898,6 +904,11 @@ def train(
                     # MoE-style models will have an aux loss which we want to compute
                     loss += output.aux_loss.float().sum()
 
+                # Check for on-demand checkpoint before backward pass
+                if full_state_checkpointer is not None and full_state_checkpointer.should_save(device):
+                    _interrupted = True
+                    break
+
                 # Ensure scalar loss even if model returns per-token loss
                 loss = (loss / batch_num_loss_counted_tokens) * world_size
                 loss_metrics = loss.detach().cpu().item()
@@ -914,6 +925,43 @@ def train(
                     loss_backward=loss.detach().item() / world_size,
                     time_per_minibatch=time.time() - mb_start_time,
                 )
+
+                # Check for on-demand checkpoint after backward pass
+                if full_state_checkpointer is not None and full_state_checkpointer.should_save(device):
+                    _interrupted = True
+                    break
+
+            # If interrupted during minibatch processing, save checkpoint
+            # using the pre-step RNG snapshot and exit. The partial gradients
+            # are discarded — resume will replay the full step.
+            if _interrupted:
+                log_rank_0("Signal received during minibatch — saving checkpoint and exiting")
+                full_state_checkpointer.save(
+                    model=model,
+                    optimizer=optimizer,
+                    lr_scheduler=lr_scheduler,
+                    training_state={
+                        "step": step,
+                        "epoch": epoch,
+                        "total_samples_accumulated": total_samples_accumulated,
+                        "total_tokens_processed": total_tokens_processed,
+                        "last_validation_loss": last_validation_loss,
+                    },
+                    checkpointer_state={
+                        "last_saved_samples": checkpointer.last_saved_samples,
+                        "last_frequency_saved_samples": checkpointer.last_frequency_saved_samples,
+                        "best_val_loss": checkpointer.best_val_loss,
+                    },
+                    data_loader=data_loader,
+                    device=device,
+                    rng_snapshot=_rng_snapshot,
+                )
+                full_state_checkpointer.cleanup()
+                log_rank_0("Full-state checkpoint saved. Exiting.")
+                dist.barrier()
+                dist.destroy_process_group()
+                os._exit(0)
+
             step += 1
             # sum the metrics from all processes
             batch_totals.reduce_batch_metrics(device)

--- a/src/mini_trainer/train.py
+++ b/src/mini_trainer/train.py
@@ -804,16 +804,13 @@ def train(
         # (Model state was already loaded in finalize_model_initialization)
         log_rank_0("Loading optimizer state from DCP checkpoint...")
         import torch.distributed.checkpoint as dcp_module
-        from torch.distributed.checkpoint.state_dict import get_optimizer_state_dict, set_optimizer_state_dict
 
         checkpoint_dir = Path(resume_from_full_state_checkpoint)
         dcp_dir = str(checkpoint_dir / "distributed")
-        optim_state = get_optimizer_state_dict(model, optimizer)
+        optim_state = optimizer.state_dict()
         dcp_module.load({"optimizer": optim_state}, checkpoint_id=dcp_dir)
-        set_optimizer_state_dict(model, optimizer, optim_state)
+        optimizer.load_state_dict(optim_state)
         log_rank_0("   ✓ Optimizer state loaded")
-        dist.barrier()
-        log_rank_0("[DEBUG] Post-resume barrier passed")
 
         log_rank_0(f"Resumed at step={step}, epoch={epoch}, samples={total_samples_accumulated}")
 
@@ -968,7 +965,8 @@ def train(
                 )
                 full_state_checkpointer.cleanup()
                 log_rank_0("Full-state checkpoint saved. Exiting.")
-                sys.exit(0)
+                destroy_distributed_environment()
+                os._exit(0)
 
             # sample-based saving, keep in the inner loop
             if checkpointer.should_save_checkpoint(

--- a/src/mini_trainer/train.py
+++ b/src/mini_trainer/train.py
@@ -18,6 +18,7 @@ from mini_trainer.batch_metrics import BatchMetrics
 from mini_trainer.sampler import get_data_loader
 from mini_trainer.setup_model_for_training import setup_model, setup_training_components
 from mini_trainer.training_types import PretrainingConfig, TrainingMode
+from mini_trainer.full_state_checkpoint import FullStateCheckpointer
 from mini_trainer.utils import (
     destroy_distributed_environment,
     get_node_rank,
@@ -680,6 +681,8 @@ def train(
     val_data_loader: torch.utils.data.DataLoader | None = None,
     validation_frequency: int | None = None,
     trust_remote_code: bool = False,
+    on_demand_checkpointing: bool = False,
+    resume_from_full_state_checkpoint: str | None = None,
 ):
     """
     Runs the model training loop.
@@ -755,9 +758,59 @@ def train(
         checkpoint_at_final=save_final_checkpoint,
     )
 
+    # Initialize on-demand full-state checkpointing if enabled
+    full_state_checkpointer = None
+    if on_demand_checkpointing:
+        full_state_checkpointer = FullStateCheckpointer(
+            checkpoint_dir=os.path.join(output_dir, "full_state_checkpoints"),
+            rank=dist.get_rank(),
+            world_size=world_size,
+        )
+        full_state_checkpointer.install_signal_handlers()
+        log_rank_0("On-demand full-state checkpointing enabled")
+
     device = next(model.parameters()).device
     epoch = 0
     last_validation_loss = None  # Track the most recent validation loss
+
+    # Restore training state from full-state checkpoint if resuming
+    if resume_from_full_state_checkpoint:
+        log_rank_0(f"Resuming from full-state checkpoint: {resume_from_full_state_checkpoint}")
+        meta = FullStateCheckpointer.load_metadata(resume_from_full_state_checkpoint)
+
+        # Restore training counters
+        step = meta["step"]
+        epoch = meta["epoch"]
+        total_samples_accumulated = meta["total_samples_accumulated"]
+        total_tokens_processed = meta["total_tokens_processed"]
+        last_validation_loss = meta.get("last_validation_loss")
+
+        # Restore checkpointer state
+        cs = meta["checkpointer_state"]
+        checkpointer.last_saved_samples = cs["last_saved_samples"]
+        checkpointer.last_frequency_saved_samples = cs["last_frequency_saved_samples"]
+        checkpointer.best_val_loss = cs["best_val_loss"]
+
+        # Restore LR scheduler
+        lr_scheduler.load_state_dict(meta["lr_scheduler_state"])
+
+        # Restore sampler epoch
+        data_loader.sampler.set_epoch(meta["sampler_epoch"])
+
+        # Restore per-rank RNG states
+        FullStateCheckpointer.load_rng_states(
+            resume_from_full_state_checkpoint, rank=dist.get_rank()
+        )
+
+        # Load optimizer state from DCP checkpoint
+        FullStateCheckpointer.load_distributed_state(
+            resume_from_full_state_checkpoint, model, optimizer
+        )
+
+        log_rank_0(f"Resumed at step={step}, epoch={epoch}, samples={total_samples_accumulated}")
+
+    # Track samples for batch-skipping when resuming mid-epoch
+    _resume_target_samples = total_samples_accumulated if resume_from_full_state_checkpoint else None
 
     # main training loop
     while not reached_stop_condition(
@@ -773,7 +826,17 @@ def train(
         data_loader.sampler.set_epoch(epoch)
         data_loader_it = iter(data_loader)
 
+        _skipped_samples = 0
         for batch in data_loader_it:
+            # Skip already-processed batches when resuming mid-epoch
+            if _resume_target_samples is not None:
+                _skipped_samples += sum(mb["num_samples"] for mb in batch)
+                if _skipped_samples < _resume_target_samples:
+                    continue
+                # Done skipping — clear the resume state
+                _resume_target_samples = None
+                log_rank_0(f"Skipped {_skipped_samples} samples to resume position")
+
             batch_start_time = time.time()
             batch_totals.reset_batch()
             torch.cuda.reset_peak_memory_stats()
@@ -871,6 +934,32 @@ def train(
                 metric_logger.log_sync(batch_metrics)
 
             dist.barrier()
+
+            # On-demand full-state checkpoint check
+            if full_state_checkpointer is not None and full_state_checkpointer.should_save(device):
+                log_rank_0("Signal received — saving full-state checkpoint and exiting")
+                full_state_checkpointer.save(
+                    model=model,
+                    optimizer=optimizer,
+                    lr_scheduler=lr_scheduler,
+                    training_state={
+                        "step": step,
+                        "epoch": epoch,
+                        "total_samples_accumulated": total_samples_accumulated,
+                        "total_tokens_processed": total_tokens_processed,
+                        "last_validation_loss": last_validation_loss,
+                    },
+                    checkpointer_state={
+                        "last_saved_samples": checkpointer.last_saved_samples,
+                        "last_frequency_saved_samples": checkpointer.last_frequency_saved_samples,
+                        "best_val_loss": checkpointer.best_val_loss,
+                    },
+                    data_loader=data_loader,
+                    device=device,
+                )
+                full_state_checkpointer.cleanup()
+                log_rank_0("Full-state checkpoint saved. Exiting.")
+                sys.exit(0)
 
             # sample-based saving, keep in the inner loop
             if checkpointer.should_save_checkpoint(
@@ -1114,6 +1203,15 @@ def main(
             )
         ),
     ] = False,
+    # On-demand full-state checkpointing
+    on_demand_checkpointing: Annotated[
+        bool,
+        Option(help="Enable signal-driven full-state checkpointing for training resumption"),
+    ] = False,
+    resume_from_full_state_checkpoint: Annotated[
+        str | None,
+        Option(help="Path to a full-state checkpoint directory to resume training from"),
+    ] = None,
     # pretraining parameters
     block_size: Annotated[
         int | None,
@@ -1335,6 +1433,7 @@ def main(
         beta2=beta2,
         eps=eps,
         weight_decay=weight_decay,
+        resume_from_checkpoint=resume_from_full_state_checkpoint,
     )
 
     train(
@@ -1359,6 +1458,8 @@ def main(
         val_data_loader=val_data_loader,
         validation_frequency=validation_frequency,
         trust_remote_code=trust_remote_code,
+        on_demand_checkpointing=on_demand_checkpointing,
+        resume_from_full_state_checkpoint=resume_from_full_state_checkpoint,
     )
 
     # once done, tear down distributed environment

--- a/src/mini_trainer/train.py
+++ b/src/mini_trainer/train.py
@@ -771,6 +771,16 @@ def train(
         full_state_checkpointer.install_signal_handlers()
         log_rank_0("On-demand full-state checkpointing enabled")
 
+        # Warn if model uses quantization — checkpoint/resume may not
+        # preserve quantization state correctly.
+        inner = getattr(model, "module", model)
+        if hasattr(inner, "_fp8_scales") or hasattr(getattr(inner, "config", None), "_fp8_scales"):
+            log_rank_0(
+                "WARNING: Model uses FP8 quantization. On-demand checkpointing "
+                "may not correctly preserve quantization scales on resume. "
+                "Verify checkpoint fidelity before relying on this in production."
+            )
+
     device = next(model.parameters()).device
     epoch = 0
     last_validation_loss = None  # Track the most recent validation loss

--- a/src/mini_trainer/train.py
+++ b/src/mini_trainer/train.py
@@ -837,10 +837,10 @@ def train(
             # Skip already-processed batches when resuming mid-epoch
             if _resume_target_step is not None:
                 _skipped_steps += 1
-                if _skipped_steps < _resume_target_step:
+                if _skipped_steps <= _resume_target_step:
                     continue
                 # Done skipping — clear the resume state
-                log_rank_0(f"Skipped {_skipped_steps} batches to resume position (target step={_resume_target_step})")
+                log_rank_0(f"Skipped {_resume_target_step} batches to resume position")
                 _resume_target_step = None
 
             batch_start_time = time.time()

--- a/src/mini_trainer/train.py
+++ b/src/mini_trainer/train.py
@@ -965,7 +965,8 @@ def train(
                 )
                 full_state_checkpointer.cleanup()
                 log_rank_0("Full-state checkpoint saved. Exiting.")
-                destroy_distributed_environment()
+                dist.barrier()
+                dist.destroy_process_group()
                 os._exit(0)
 
             # sample-based saving, keep in the inner loop

--- a/src/mini_trainer/train.py
+++ b/src/mini_trainer/train.py
@@ -15,10 +15,10 @@ from typer import Option, Typer
 from mini_trainer import mlflow_wrapper, wandb_wrapper
 from mini_trainer.async_structured_logger import AsyncStructuredLogger
 from mini_trainer.batch_metrics import BatchMetrics
+from mini_trainer.full_state_checkpoint import FullStateCheckpointer
 from mini_trainer.sampler import get_data_loader
 from mini_trainer.setup_model_for_training import setup_model, setup_training_components
 from mini_trainer.training_types import PretrainingConfig, TrainingMode
-from mini_trainer.full_state_checkpoint import FullStateCheckpointer
 from mini_trainer.utils import (
     destroy_distributed_environment,
     get_node_rank,
@@ -798,15 +798,14 @@ def train(
         data_loader.sampler.set_epoch(meta["sampler_epoch"])
 
         # Restore per-rank RNG states
-        FullStateCheckpointer.load_rng_states(
-            resume_from_full_state_checkpoint, rank=dist.get_rank()
-        )
+        FullStateCheckpointer.load_rng_states(resume_from_full_state_checkpoint, rank=dist.get_rank())
 
         # Load optimizer state from DCP checkpoint
         # (Model state was already loaded in finalize_model_initialization)
         log_rank_0("Loading optimizer state from DCP checkpoint...")
         import torch.distributed.checkpoint as dcp_module
         from torch.distributed.checkpoint.state_dict import get_optimizer_state_dict, set_optimizer_state_dict
+
         checkpoint_dir = Path(resume_from_full_state_checkpoint)
         dcp_dir = str(checkpoint_dir / "distributed")
         optim_state = get_optimizer_state_dict(model, optimizer)

--- a/src/mini_trainer/train.py
+++ b/src/mini_trainer/train.py
@@ -1,11 +1,13 @@
 import json
 import logging
 import os
+import random
 import sys
 import time
 from pathlib import Path
 from typing import Annotated, Literal
 
+import numpy as np
 import torch
 import torch.distributed as dist
 from torch.distributed._tensor.api import DTensor as _DTensor  # works if DTensor is available
@@ -800,16 +802,20 @@ def train(
         # Restore per-rank RNG states
         FullStateCheckpointer.load_rng_states(resume_from_full_state_checkpoint, rank=dist.get_rank())
 
-        # Load optimizer state from DCP checkpoint
-        # (Model state was already loaded in finalize_model_initialization)
-        log_rank_0("Loading optimizer state from DCP checkpoint...")
-        import torch.distributed.checkpoint as dcp_module
-
-        checkpoint_dir = Path(resume_from_full_state_checkpoint)
-        dcp_dir = str(checkpoint_dir / "distributed")
-        optim_state = optimizer.state_dict()
-        dcp_module.load({"optimizer": optim_state}, checkpoint_id=dcp_dir)
-        optimizer.load_state_dict(optim_state)
+        # Load optimizer state (model state was loaded in finalize_model_initialization).
+        # We need to pre-populate optimizer state entries (exp_avg, exp_avg_sq, step)
+        # before loading, because the checkpoint was saved with DTensor shards that
+        # need matching DTensor structure in the optimizer.
+        log_rank_0("Loading optimizer state...")
+        for group in optimizer.param_groups:
+            for p in group["params"]:
+                if p not in optimizer.state:
+                    optimizer.state[p] = {
+                        "step": torch.tensor(0.0),
+                        "exp_avg": torch.zeros_like(p),
+                        "exp_avg_sq": torch.zeros_like(p),
+                    }
+        FullStateCheckpointer.load_optimizer_state(resume_from_full_state_checkpoint, optimizer, rank=dist.get_rank())
         log_rank_0("   ✓ Optimizer state loaded")
 
         log_rank_0(f"Resumed at step={step}, epoch={epoch}, samples={total_samples_accumulated}")
@@ -842,6 +848,17 @@ def train(
                 # Done skipping — clear the resume state
                 log_rank_0(f"Skipped {_resume_target_step} batches to resume position")
                 _resume_target_step = None
+
+            # Snapshot RNG state at the start of this training step, BEFORE
+            # any gradient accumulation. If we checkpoint mid-step, we save
+            # this snapshot so resume replays the step from the beginning.
+            _rng_snapshot = {
+                "torch_rng": torch.get_rng_state(),
+                "python_rng": random.getstate(),
+                "numpy_rng": np.random.get_state(),
+            }
+            if torch.cuda.is_available() and torch.cuda.is_initialized():
+                _rng_snapshot["cuda_rng"] = torch.cuda.get_rng_state()
 
             batch_start_time = time.time()
             batch_totals.reset_batch()
@@ -962,6 +979,7 @@ def train(
                     },
                     data_loader=data_loader,
                     device=device,
+                    rng_snapshot=_rng_snapshot,
                 )
                 full_state_checkpointer.cleanup()
                 log_rank_0("Full-state checkpoint saved. Exiting.")

--- a/src/mini_trainer/train.py
+++ b/src/mini_trainer/train.py
@@ -1393,6 +1393,36 @@ def main(
         trust_remote_code=trust_remote_code,
     )
 
+    # When resuming, ensure model architecture matches the checkpoint.
+    # The first training run may have resized embeddings (e.g., vocab alignment),
+    # creating a new base model f'. Resume must load f', not re-derive from f.
+    if resume_from_full_state_checkpoint:
+        # Ensure the model's architecture matches the checkpoint (f' not f).
+        # The first training run may have resized embeddings, creating f'.
+        # We read the checkpoint's DCP metadata to get the actual saved embedding
+        # shape and resize if needed so f'' == f'.
+        from torch.distributed.checkpoint import FileSystemReader
+
+        dcp_dir = os.path.join(resume_from_full_state_checkpoint, "distributed")
+        if os.path.isdir(dcp_dir):
+            reader = FileSystemReader(dcp_dir)
+            dcp_meta = reader.read_metadata()
+            for fqn, tensor_meta in dcp_meta.state_dict_metadata.items():
+                if "embed_tokens.weight" in fqn and hasattr(tensor_meta, "size"):
+                    ckpt_embed_size = tensor_meta.size[0]
+                    inner = model
+                    for attr in ["model", "embed_tokens"]:
+                        inner = getattr(inner, attr, inner)
+                    if hasattr(inner, "weight"):
+                        current_size = inner.weight.shape[0]
+                        if current_size != ckpt_embed_size:
+                            log_rank_0(
+                                f"Resizing model embeddings from {current_size} to {ckpt_embed_size} "
+                                f"to match checkpoint (f' architecture)"
+                            )
+                            model.resize_token_embeddings(ckpt_embed_size)
+                    break
+
     # Create PretrainingConfig if block_size is provided
     pretraining_config = None
     if block_size is not None:

--- a/src/mini_trainer/training_types.py
+++ b/src/mini_trainer/training_types.py
@@ -235,3 +235,20 @@ class TrainingArgs:
         default=0.0,
         metadata={"help": "Minimum validation loss improvement required to trigger a save"},
     )
+
+    # On-demand full-state checkpointing
+    on_demand_checkpointing: bool = field(
+        default=False,
+        metadata={
+            "help": "Enable signal-driven full-state checkpointing. When enabled, the training process "
+            "will catch termination signals (SIGTERM, SIGINT, SIGUSR1, etc.) and save complete training "
+            "state (model, optimizer, scheduler, RNG) before exiting."
+        },
+    )
+    resume_from_full_state_checkpoint: str | None = field(
+        default=None,
+        metadata={
+            "help": "Path to a full-state checkpoint directory to resume training from. "
+            "The checkpoint must have been saved by the on-demand checkpointing system."
+        },
+    )

--- a/tests/test_api_train.py
+++ b/tests/test_api_train.py
@@ -534,9 +534,8 @@ class TestRunTraining:
             with pytest.raises(KeyboardInterrupt):
                 run_training(torch_args, train_args)
 
-            # Verify cleanup was attempted
-            mock_popen.terminate.assert_called_once()
-            mock_popen.wait.assert_called_once()
+            # Verify wait was called for process cleanup
+            mock_popen.wait.assert_called()
 
     @patch("mini_trainer.api_train.StreamablePopen")
     def test_run_training_process_failure(self, mock_popen_class):
@@ -560,7 +559,6 @@ class TestRunTraining:
                 run_training(torch_args, train_args)
 
             assert "Training failed" in str(exc_info.value)
-            mock_popen.terminate.assert_called_once()
 
 
 class TestEnums:

--- a/tests/test_api_train.py
+++ b/tests/test_api_train.py
@@ -201,6 +201,10 @@ class TestStreamablePopen:
         import threading
         import time
 
+        # Use 2x buffer_time between child outputs so test checks fall
+        # safely between outputs, avoiding timing races in CI.
+        child_delay = self.buffer_time * 2
+
         with tempfile.TemporaryDirectory() as tmpdir:
             log_file = Path(tmpdir) / "stdout_realtime_test.log"
             # Script that outputs "1", "2", "3" with delays
@@ -209,9 +213,9 @@ class TestStreamablePopen:
                 "-c",
                 "import time, sys; "
                 "print('1', flush=True); "
-                f"time.sleep({self.buffer_time}); "
+                f"time.sleep({child_delay}); "
                 "print('2', flush=True); "
-                f"time.sleep({self.buffer_time}); "
+                f"time.sleep({child_delay}); "
                 "print('3', flush=True)",
             ]
 
@@ -222,7 +226,7 @@ class TestStreamablePopen:
             listen_thread.start()
 
             # Check that "1" appears first
-            time.sleep(self.buffer_time)  # Increased delay for CI environments to start subprocess
+            time.sleep(self.buffer_time)  # Wait for subprocess startup + first output
             with open(log_file) as f:
                 content = f.read()
                 assert "1" in content, f"Expected '1' in content but got: {content!r}"
@@ -230,7 +234,7 @@ class TestStreamablePopen:
                 assert "3" not in content
 
             # Check that "2" appears next
-            time.sleep(self.buffer_time)  # Wait for "2" to be printed
+            time.sleep(child_delay)  # Wait for "2" to be printed
             with open(log_file) as f:
                 content = f.read()
                 assert "1" in content
@@ -238,7 +242,7 @@ class TestStreamablePopen:
                 assert "3" not in content
 
             # Check that "3" appears last
-            time.sleep(self.buffer_time)  # Wait for "3" to be printed
+            time.sleep(child_delay)  # Wait for "3" to be printed
             with open(log_file) as f:
                 content = f.read()
                 assert "1" in content
@@ -253,6 +257,10 @@ class TestStreamablePopen:
         import threading
         import time
 
+        # Use 2x buffer_time between child outputs so test checks fall
+        # safely between outputs, avoiding timing races in CI.
+        child_delay = self.buffer_time * 2
+
         with tempfile.TemporaryDirectory() as tmpdir:
             log_file = Path(tmpdir) / "stderr_realtime_test.log"
             # Script that outputs "1", "2", "3" to stderr with delays
@@ -261,9 +269,9 @@ class TestStreamablePopen:
                 "-c",
                 "import time, sys; "
                 "print('1', file=sys.stderr, flush=True); "
-                f"time.sleep({self.buffer_time}); "
+                f"time.sleep({child_delay}); "
                 "print('2', file=sys.stderr, flush=True); "
-                f"time.sleep({self.buffer_time}); "
+                f"time.sleep({child_delay}); "
                 "print('3', file=sys.stderr, flush=True)",
             ]
 
@@ -274,7 +282,7 @@ class TestStreamablePopen:
             listen_thread.start()
 
             # Check that "1" appears first
-            time.sleep(self.buffer_time)  # Increased delay for CI environments to start subprocess
+            time.sleep(self.buffer_time)  # Wait for subprocess startup + first output
             with open(log_file) as f:
                 content = f.read()
                 assert "1" in content, f"Expected '1' in content but got: {content!r}"
@@ -282,7 +290,7 @@ class TestStreamablePopen:
                 assert "3" not in content
 
             # Check that "2" appears next
-            time.sleep(self.buffer_time)  # Wait for "2" to be printed
+            time.sleep(child_delay)  # Wait for "2" to be printed
             with open(log_file) as f:
                 content = f.read()
                 assert "1" in content
@@ -290,7 +298,7 @@ class TestStreamablePopen:
                 assert "3" not in content
 
             # Check that "3" appears last
-            time.sleep(self.buffer_time)  # Wait for "3" to be printed
+            time.sleep(child_delay)  # Wait for "3" to be printed
             with open(log_file) as f:
                 content = f.read()
                 assert "1" in content
@@ -305,6 +313,10 @@ class TestStreamablePopen:
         import threading
         import time
 
+        # Use 2x buffer_time between child outputs so test checks fall
+        # safely between outputs, avoiding timing races in CI.
+        child_delay = self.buffer_time * 2
+
         with tempfile.TemporaryDirectory() as tmpdir:
             log_file = Path(tmpdir) / "mixed_realtime_test.log"
             # Script that alternates between stdout and stderr with delays
@@ -313,11 +325,11 @@ class TestStreamablePopen:
                 "-c",
                 "import time, sys; "
                 "print('stdout-1', flush=True); "
-                f"time.sleep({self.buffer_time}); "
+                f"time.sleep({child_delay}); "
                 "print('stderr-1', file=sys.stderr, flush=True); "
-                f"time.sleep({self.buffer_time}); "
+                f"time.sleep({child_delay}); "
                 "print('stdout-2', flush=True); "
-                f"time.sleep({self.buffer_time}); "
+                f"time.sleep({child_delay}); "
                 "print('stderr-2', file=sys.stderr, flush=True)",
             ]
 
@@ -328,7 +340,7 @@ class TestStreamablePopen:
             listen_thread.start()
 
             # Check first stdout appears
-            time.sleep(self.buffer_time)  # Increased initial delay for CI environments
+            time.sleep(self.buffer_time)  # Wait for subprocess startup + first output
             with open(log_file) as f:
                 content = f.read()
                 assert "stdout-1" in content, f"Expected 'stdout-1' in content but got: {content!r}"
@@ -337,7 +349,7 @@ class TestStreamablePopen:
                 assert "stderr-2" not in content
 
             # Check first stderr appears
-            time.sleep(self.buffer_time)
+            time.sleep(child_delay)
             with open(log_file) as f:
                 content = f.read()
                 assert "stdout-1" in content
@@ -346,7 +358,7 @@ class TestStreamablePopen:
                 assert "stderr-2" not in content
 
             # Check second stdout appears
-            time.sleep(self.buffer_time)
+            time.sleep(child_delay)
             with open(log_file) as f:
                 content = f.read()
                 assert "stdout-1" in content
@@ -355,7 +367,7 @@ class TestStreamablePopen:
                 assert "stderr-2" not in content
 
             # Check second stderr appears
-            time.sleep(self.buffer_time)  # Increased delay to ensure last output is written
+            time.sleep(child_delay)
             with open(log_file) as f:
                 content = f.read()
                 assert "stdout-1" in content

--- a/tests/test_full_state_checkpoint.py
+++ b/tests/test_full_state_checkpoint.py
@@ -60,3 +60,242 @@ class TestTrainingArgsCheckpointFields:
             resume_from_full_state_checkpoint="/tmp/checkpoint",
         )
         assert args.resume_from_full_state_checkpoint == "/tmp/checkpoint"
+
+
+from mini_trainer.full_state_checkpoint import FullStateCheckpointer
+
+
+class TestFullStateCheckpointerSignals:
+    def test_trigger_file_created_on_signal(self, tmp_path):
+        trigger_path = tmp_path / "trigger"
+        ckpt = FullStateCheckpointer(
+            checkpoint_dir=str(tmp_path / "ckpts"),
+            rank=0,
+            world_size=1,
+            trigger_path=str(trigger_path),
+        )
+        ckpt.install_signal_handlers()
+        os.kill(os.getpid(), signal.SIGUSR1)
+        assert trigger_path.exists()
+        ckpt.cleanup()
+
+    def test_cleanup_removes_trigger_file(self, tmp_path):
+        trigger_path = tmp_path / "trigger"
+        trigger_path.touch()
+        ckpt = FullStateCheckpointer(
+            checkpoint_dir=str(tmp_path / "ckpts"),
+            rank=0,
+            world_size=1,
+            trigger_path=str(trigger_path),
+        )
+        ckpt.cleanup()
+        assert not trigger_path.exists()
+
+    def test_cleanup_noop_if_no_trigger_file(self, tmp_path):
+        trigger_path = tmp_path / "trigger"
+        ckpt = FullStateCheckpointer(
+            checkpoint_dir=str(tmp_path / "ckpts"),
+            rank=0,
+            world_size=1,
+            trigger_path=str(trigger_path),
+        )
+        ckpt.cleanup()
+
+    def test_all_signals_handled(self, tmp_path):
+        trigger_path = tmp_path / "trigger"
+        ckpt = FullStateCheckpointer(
+            checkpoint_dir=str(tmp_path / "ckpts"),
+            rank=0,
+            world_size=1,
+            trigger_path=str(trigger_path),
+        )
+        ckpt.install_signal_handlers()
+        os.kill(os.getpid(), signal.SIGUSR2)
+        assert trigger_path.exists()
+        ckpt.cleanup()
+
+
+class TestFullStateCheckpointerTriggerDetection:
+    def test_should_save_false_when_no_trigger(self, tmp_path):
+        trigger_path = tmp_path / "trigger"
+        ckpt = FullStateCheckpointer(
+            checkpoint_dir=str(tmp_path / "ckpts"),
+            rank=0,
+            world_size=1,
+            trigger_path=str(trigger_path),
+        )
+        with patch("mini_trainer.full_state_checkpoint.dist") as mock_dist:
+            mock_dist.is_initialized.return_value = False
+            assert ckpt.should_save(torch.device("cpu")) is False
+
+    def test_should_save_true_when_trigger_exists(self, tmp_path):
+        trigger_path = tmp_path / "trigger"
+        trigger_path.touch()
+        ckpt = FullStateCheckpointer(
+            checkpoint_dir=str(tmp_path / "ckpts"),
+            rank=0,
+            world_size=1,
+            trigger_path=str(trigger_path),
+        )
+        with patch("mini_trainer.full_state_checkpoint.dist") as mock_dist:
+            mock_dist.is_initialized.return_value = False
+            assert ckpt.should_save(torch.device("cpu")) is True
+
+
+class TestFullStateCheckpointerMetadata:
+    def test_save_training_metadata_creates_file(self, tmp_path):
+        ckpt = FullStateCheckpointer(
+            checkpoint_dir=str(tmp_path),
+            rank=0,
+            world_size=1,
+            trigger_path=str(tmp_path / "trigger"),
+        )
+        training_state = {
+            "step": 10,
+            "epoch": 1,
+            "total_samples_accumulated": 100,
+            "total_tokens_processed": 5000,
+            "last_validation_loss": 2.5,
+        }
+        checkpointer_state = {
+            "last_saved_samples": 80,
+            "last_frequency_saved_samples": 80,
+            "best_val_loss": 2.7,
+        }
+        lr_scheduler_state = {"last_epoch": 10, "_step_count": 11}
+
+        save_dir = tmp_path / "step_10"
+        save_dir.mkdir()
+
+        ckpt._save_metadata(
+            save_dir=save_dir,
+            training_state=training_state,
+            checkpointer_state=checkpointer_state,
+            lr_scheduler_state=lr_scheduler_state,
+            sampler_epoch=1,
+        )
+
+        meta_path = save_dir / "training_state.pt"
+        assert meta_path.exists()
+        meta = torch.load(meta_path, weights_only=False)
+        assert meta["step"] == 10
+        assert meta["epoch"] == 1
+        assert meta["total_samples_accumulated"] == 100
+        assert meta["total_tokens_processed"] == 5000
+        assert meta["last_validation_loss"] == 2.5
+        assert meta["checkpointer_state"]["best_val_loss"] == 2.7
+        assert meta["lr_scheduler_state"]["last_epoch"] == 10
+        assert meta["sampler_epoch"] == 1
+
+    def test_save_rng_state_creates_per_rank_file(self, tmp_path):
+        ckpt = FullStateCheckpointer(
+            checkpoint_dir=str(tmp_path),
+            rank=3,
+            world_size=8,
+            trigger_path=str(tmp_path / "trigger"),
+        )
+        save_dir = tmp_path / "step_5"
+        save_dir.mkdir()
+
+        ckpt._save_rng_states(save_dir)
+
+        rng_path = save_dir / "rng_state_rank_3.pt"
+        assert rng_path.exists()
+        rng = torch.load(rng_path, weights_only=False)
+        assert "torch_rng" in rng
+        assert "python_rng" in rng
+        assert "numpy_rng" in rng
+
+    def test_metadata_roundtrip(self, tmp_path):
+        ckpt = FullStateCheckpointer(
+            checkpoint_dir=str(tmp_path),
+            rank=0,
+            world_size=1,
+            trigger_path=str(tmp_path / "trigger"),
+        )
+        save_dir = tmp_path / "step_7"
+        save_dir.mkdir()
+
+        original_state = {
+            "step": 7,
+            "epoch": 0,
+            "total_samples_accumulated": 42,
+            "total_tokens_processed": 2100,
+            "last_validation_loss": None,
+        }
+        ckpt._save_metadata(
+            save_dir=save_dir,
+            training_state=original_state,
+            checkpointer_state={"last_saved_samples": 0, "last_frequency_saved_samples": 0, "best_val_loss": None},
+            lr_scheduler_state={"_step_count": 8},
+            sampler_epoch=0,
+        )
+        ckpt._save_rng_states(save_dir)
+
+        loaded_meta = torch.load(save_dir / "training_state.pt", weights_only=False)
+        loaded_rng = torch.load(save_dir / "rng_state_rank_0.pt", weights_only=False)
+
+        assert loaded_meta["step"] == 7
+        assert loaded_meta["last_validation_loss"] is None
+        assert loaded_rng["torch_rng"] is not None
+
+
+class TestFullStateCheckpointerLoad:
+    def test_load_metadata(self, tmp_path):
+        save_dir = tmp_path / "step_5"
+        save_dir.mkdir()
+        metadata = {
+            "step": 5,
+            "epoch": 0,
+            "total_samples_accumulated": 50,
+            "total_tokens_processed": 2500,
+            "last_validation_loss": 3.1,
+            "checkpointer_state": {
+                "last_saved_samples": 40,
+                "last_frequency_saved_samples": 40,
+                "best_val_loss": None,
+            },
+            "lr_scheduler_state": {"_step_count": 6},
+            "sampler_epoch": 0,
+        }
+        torch.save(metadata, save_dir / "training_state.pt")
+
+        loaded = FullStateCheckpointer.load_metadata(save_dir)
+        assert loaded["step"] == 5
+        assert loaded["total_samples_accumulated"] == 50
+        assert loaded["checkpointer_state"]["last_saved_samples"] == 40
+
+    def test_load_rng_states(self, tmp_path):
+        save_dir = tmp_path / "step_5"
+        save_dir.mkdir()
+
+        original_torch_rng = torch.get_rng_state()
+        original_python_rng = random.getstate()
+        original_numpy_rng = np.random.get_state()
+
+        rng_state = {
+            "torch_rng": original_torch_rng,
+            "python_rng": original_python_rng,
+            "numpy_rng": original_numpy_rng,
+        }
+        torch.save(rng_state, save_dir / "rng_state_rank_0.pt")
+
+        # Advance RNG states
+        torch.randn(100)
+        random.random()
+        np.random.rand(100)
+
+        # Restore
+        FullStateCheckpointer.load_rng_states(save_dir, rank=0)
+
+        assert torch.equal(torch.get_rng_state(), original_torch_rng)
+
+    def test_load_metadata_missing_file(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            FullStateCheckpointer.load_metadata(tmp_path / "nonexistent")
+
+    def test_load_rng_states_missing_file(self, tmp_path):
+        save_dir = tmp_path / "step_5"
+        save_dir.mkdir()
+        with pytest.raises(FileNotFoundError):
+            FullStateCheckpointer.load_rng_states(save_dir, rank=99)

--- a/tests/test_full_state_checkpoint.py
+++ b/tests/test_full_state_checkpoint.py
@@ -3,13 +3,11 @@
 import os
 import random
 import signal
-from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import numpy as np
 import pytest
 import torch
-import torch.distributed as dist
 
 from mini_trainer.training_types import TrainingArgs
 

--- a/tests/test_full_state_checkpoint.py
+++ b/tests/test_full_state_checkpoint.py
@@ -1,0 +1,62 @@
+"""Tests for full-state on-demand checkpointing."""
+
+import os
+import random
+import signal
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+import torch
+import torch.distributed as dist
+
+from mini_trainer.training_types import TrainingArgs
+
+
+class TestTrainingArgsCheckpointFields:
+    def test_on_demand_checkpointing_defaults_false(self):
+        args = TrainingArgs(
+            model_name_or_path="test",
+            data_path="test.jsonl",
+            batch_size=1,
+            max_tokens_per_gpu=512,
+            learning_rate=1e-4,
+            output_dir="/tmp/test",
+        )
+        assert args.on_demand_checkpointing is False
+
+    def test_resume_from_full_state_checkpoint_defaults_none(self):
+        args = TrainingArgs(
+            model_name_or_path="test",
+            data_path="test.jsonl",
+            batch_size=1,
+            max_tokens_per_gpu=512,
+            learning_rate=1e-4,
+            output_dir="/tmp/test",
+        )
+        assert args.resume_from_full_state_checkpoint is None
+
+    def test_on_demand_checkpointing_can_be_set(self):
+        args = TrainingArgs(
+            model_name_or_path="test",
+            data_path="test.jsonl",
+            batch_size=1,
+            max_tokens_per_gpu=512,
+            learning_rate=1e-4,
+            output_dir="/tmp/test",
+            on_demand_checkpointing=True,
+        )
+        assert args.on_demand_checkpointing is True
+
+    def test_resume_path_can_be_set(self):
+        args = TrainingArgs(
+            model_name_or_path="test",
+            data_path="test.jsonl",
+            batch_size=1,
+            max_tokens_per_gpu=512,
+            learning_rate=1e-4,
+            output_dir="/tmp/test",
+            resume_from_full_state_checkpoint="/tmp/checkpoint",
+        )
+        assert args.resume_from_full_state_checkpoint == "/tmp/checkpoint"


### PR DESCRIPTION
## Summary

Implements signal-driven full-state checkpointing that enables exact training resumption for OSFT models in Kubernetes/OpenShift/SLURM environments.

- **Signal handling**: Catches 7 termination signals (SIGTERM, SIGINT, SIGUSR1/2, SIGXCPU, SIGHUP, SIGQUIT) covering Kubernetes, SLURM, PBS, and LSF schedulers
- **Trigger mechanism**: Signal handler writes to `/dev/shm` trigger file; workers poll at batch boundaries and coordinate via `all_reduce(MAX)` for distributed consensus
- **DCP sharded save**: Each rank saves its own shard via `torch.distributed.checkpoint` — no gathering to rank 0, minimal communication overhead
- **Exact resumption**: Saves complete training state (model OSFT factors, optimizer, LR scheduler, per-rank RNG states, training counters, checkpointer state) enabling bit-identical optimization trajectories after resume
- **OSFT-aware resume**: On restart, the model structure is initialized normally (with SVD computation for meta tensor materialization), then all parameters are overwritten with checkpoint values via DCP in-place load

### New files
- `src/mini_trainer/full_state_checkpoint.py` — `FullStateCheckpointer` class
- `tests/test_full_state_checkpoint.py` — 17 unit tests
- `regression_tests/test_full_state_checkpoint_fidelity.py` — Trajectory fidelity test
- `regression_tests/run_multi_node_fidelity_test.sh` — Multi-node simulation test (2 nodes x 4 GPUs)
- `regression_tests/test_full_state_checkpoint_signal.sh` — Signal-triggered end-to-end test

### Modified files
- `src/mini_trainer/training_types.py` — Added `on_demand_checkpointing` and `resume_from_full_state_checkpoint` fields
- `src/mini_trainer/setup_model_for_training.py` — Resume path in `finalize_model_initialization()` that loads from DCP instead of computing SVD
- `src/mini_trainer/train.py` — Training loop integration with save trigger, resume state restoration, and step-based batch skipping

## Test plan

- [x] 17 unit tests for signal handling, trigger detection, metadata/RNG roundtrip, load/save mechanics
- [x] 276 existing unit tests still pass (0 regressions)
- [x] Optimization trajectory fidelity test: 20-step baseline vs checkpoint-at-10/resume proves **bit-identical** loss, grad_norm, lr, and parameter hashes across all steps
- [x] Multi-node fidelity test: Same fidelity verification across 2 simulated nodes (8 GPUs total)
- [x] Signal-triggered end-to-end test: Training with `--on-demand-checkpointing` in infinite mode, trigger file written, all ranks checkpoint and exit cleanly, resume continues from correct step
- [x] Ruff lint and format checks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * On‑demand, signal‑triggered full‑state checkpointing for distributed training.
  * Resume from full‑state checkpoints restoring model shards, optimizer, RNG, scheduler and training progress; new CLI flags to enable checkpointing and resume.

* **Documentation**
  * Added a comprehensive design spec for on‑demand full‑state checkpointing.

* **Tests**
  * Added unit tests and multiple regression harnesses (multi‑node, signal‑trigger, per‑model matrix) validating fidelity and resume workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->