### PR TITLE
Relax numba pin from >=0.62.0 to >=0.61.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "datasets",
     "transformers>=4.57.1",
     "ninja",
-    "numba>=0.62.0",
+    "numba>=0.61.2",
     "rich",
 ]
 


### PR DESCRIPTION
## Summary
Relaxes the numba version pin from `>=0.62.0` to `>=0.61.2` to resolve a dependency conflict with vllm, which pins `numba==0.61.2`.

The numba usage in this project (basic `@njit` decorators and `int64` types) is fully compatible with numba 0.61.x — no 0.62-specific APIs are used.

## Motivation
When installing alongside `vllm<=0.15.1` (used by verl for GRPO training), pip/uv cannot satisfy both `numba>=0.62.0` and vllm's `numba==0.61.2` pin, causing dependency resolution failures.