### PR TITLE
Rename checkpoint trigger file to be product-agnostic

### DIFF
--- a/regression_tests/test_checkpoint_all_models.py
+++ b/regression_tests/test_checkpoint_all_models.py
@@ -105,7 +105,7 @@ MODELS = {
 _REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 DATA_PATH = os.path.join(_REPO_ROOT, ".test_artifacts", "messages_data.jsonl")
 BASE_OUTPUT = os.path.join(_REPO_ROOT, ".test_artifacts", "runs")
-TRIGGER_FILE = "/dev/shm/mini_trainer_checkpoint_trigger"
+TRIGGER_FILE = "/dev/shm/checkpoint_requested"
 NUM_GPUS = 8
 
 

--- a/src/mini_trainer/full_state_checkpoint.py
+++ b/src/mini_trainer/full_state_checkpoint.py
@@ -11,6 +11,7 @@ all_reduce(MAX) to ensure all ranks agree.
 """
 
 import logging
+import os
 import random
 import signal
 from pathlib import Path
@@ -39,7 +40,7 @@ _CHECKPOINT_SIGNALS = (
     signal.SIGQUIT,
 )
 
-_DEFAULT_TRIGGER_PATH = "/dev/shm/mini_trainer_checkpoint_trigger"
+_DEFAULT_TRIGGER_PATH = f'/dev/shm/{os.environ.get("CHECKPOINT_TRIGGER_FILENAME", "checkpoint_requested")}'
 
 
 class FullStateCheckpointer:

--- a/src/mini_trainer/full_state_checkpoint.py
+++ b/src/mini_trainer/full_state_checkpoint.py
@@ -40,7 +40,7 @@ _CHECKPOINT_SIGNALS = (
     signal.SIGQUIT,
 )
 
-_DEFAULT_TRIGGER_PATH = f'/dev/shm/{os.environ.get("CHECKPOINT_TRIGGER_FILENAME", "checkpoint_requested")}'
+_DEFAULT_TRIGGER_PATH = f"/dev/shm/{os.environ.get('CHECKPOINT_TRIGGER_FILENAME', 'checkpoint_requested')}"
 
 
 class FullStateCheckpointer:


### PR DESCRIPTION
## Summary
- Rename the default checkpoint trigger filename from `mini_trainer_checkpoint_trigger` to `checkpoint_requested` to align with the training repo's trigger filename convention
- Add `CHECKPOINT_TRIGGER_FILENAME` env var override so the trigger filename can be customized without code changes
- Update regression test to use the new default filename

## Test plan
- [x] All 17 unit tests in `tests/test_full_state_checkpoint.py` pass (tests use explicit `trigger_path` so are unaffected by the default change)
- [ ] Regression test `regression_tests/test_checkpoint_all_models.py` validated on GPU cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)