### PR TITLE
Add auto-detection of full-state checkpoints for OSFT resume

### DIFF
--- a/src/mini_trainer/full_state_checkpoint.py
+++ b/src/mini_trainer/full_state_checkpoint.py
@@ -43,6 +43,22 @@ _CHECKPOINT_SIGNALS = (
 _DEFAULT_TRIGGER_PATH = f"/dev/shm/{os.environ.get('CHECKPOINT_TRIGGER_FILENAME', 'checkpoint_requested')}"
 
 
+def find_latest_full_state_checkpoint(output_dir: str | Path) -> str | None:
+    """Return the path to the latest full-state checkpoint in output_dir, or None."""
+    ckpt_dir = Path(output_dir) / "full_state_checkpoints"
+    if not ckpt_dir.is_dir():
+        return None
+    step_dirs = [
+        d
+        for d in ckpt_dir.iterdir()
+        if d.is_dir() and d.name.startswith("step_") and (d / "training_state.pt").exists()
+    ]
+    if not step_dirs:
+        return None
+    latest = max(step_dirs, key=lambda d: int(d.name.split("_")[1]))
+    return str(latest)
+
+
 class FullStateCheckpointer:
     """Manages signal-driven full-state checkpointing for distributed training.
 

--- a/src/mini_trainer/full_state_checkpoint.py
+++ b/src/mini_trainer/full_state_checkpoint.py
@@ -48,14 +48,17 @@ def find_latest_full_state_checkpoint(output_dir: str | Path) -> str | None:
     ckpt_dir = Path(output_dir) / "full_state_checkpoints"
     if not ckpt_dir.is_dir():
         return None
-    step_dirs = [
-        d
-        for d in ckpt_dir.iterdir()
-        if d.is_dir() and d.name.startswith("step_") and (d / "training_state.pt").exists()
-    ]
+    step_dirs: list[tuple[int, Path]] = []
+    for d in ckpt_dir.iterdir():
+        if not (d.is_dir() and d.name.startswith("step_") and (d / "training_state.pt").exists()):
+            continue
+        step_suffix = d.name.removeprefix("step_")
+        if not step_suffix.isdigit():
+            continue
+        step_dirs.append((int(step_suffix), d))
     if not step_dirs:
         return None
-    latest = max(step_dirs, key=lambda d: int(d.name.split("_")[1]))
+    latest = max(step_dirs, key=lambda item: item[0])[1]
     return str(latest)
 
 

--- a/src/mini_trainer/train.py
+++ b/src/mini_trainer/train.py
@@ -17,7 +17,7 @@ from typer import Option, Typer
 from mini_trainer import mlflow_wrapper, wandb_wrapper
 from mini_trainer.async_structured_logger import AsyncStructuredLogger
 from mini_trainer.batch_metrics import BatchMetrics
-from mini_trainer.full_state_checkpoint import FullStateCheckpointer
+from mini_trainer.full_state_checkpoint import FullStateCheckpointer, find_latest_full_state_checkpoint
 from mini_trainer.sampler import get_data_loader
 from mini_trainer.setup_model_for_training import setup_model, setup_training_components
 from mini_trainer.training_types import PretrainingConfig, TrainingMode
@@ -1310,6 +1310,12 @@ def main(
     # at this point
     output_path = Path(output_dir)
     output_path.mkdir(parents=True, exist_ok=True)
+
+    if on_demand_checkpointing and resume_from_full_state_checkpoint is None:
+        detected = find_latest_full_state_checkpoint(output_dir)
+        if detected:
+            resume_from_full_state_checkpoint = detected
+            log_rank_0(f"Auto-detected full-state checkpoint: {detected}")
 
     # validation, do this before continuing execution flow so we don't log experiments that are invalid from
     # the get-go

--- a/tests/test_full_state_checkpoint.py
+++ b/tests/test_full_state_checkpoint.py
@@ -9,6 +9,7 @@ import numpy as np
 import pytest
 import torch
 
+from mini_trainer.full_state_checkpoint import find_latest_full_state_checkpoint
 from mini_trainer.training_types import TrainingArgs
 
 
@@ -297,3 +298,42 @@ class TestFullStateCheckpointerLoad:
         save_dir.mkdir()
         with pytest.raises(FileNotFoundError):
             FullStateCheckpointer.load_rng_states(save_dir, rank=99)
+
+
+class TestFindLatestFullStateCheckpoint:
+    def _make_checkpoint(self, base_dir, step):
+        step_dir = base_dir / "full_state_checkpoints" / f"step_{step}"
+        step_dir.mkdir(parents=True)
+        torch.save({"step": step}, step_dir / "training_state.pt")
+        return step_dir
+
+    def test_returns_none_when_no_checkpoint_dir(self, tmp_path):
+        assert find_latest_full_state_checkpoint(tmp_path) is None
+
+    def test_returns_none_when_empty_checkpoint_dir(self, tmp_path):
+        (tmp_path / "full_state_checkpoints").mkdir()
+        assert find_latest_full_state_checkpoint(tmp_path) is None
+
+    def test_finds_single_checkpoint(self, tmp_path):
+        step_dir = self._make_checkpoint(tmp_path, 10)
+        assert find_latest_full_state_checkpoint(tmp_path) == str(step_dir)
+
+    def test_finds_latest_among_multiple(self, tmp_path):
+        self._make_checkpoint(tmp_path, 5)
+        self._make_checkpoint(tmp_path, 20)
+        self._make_checkpoint(tmp_path, 10)
+        result = find_latest_full_state_checkpoint(tmp_path)
+        assert result.endswith("step_20")
+
+    def test_skips_incomplete_checkpoints(self, tmp_path):
+        valid = self._make_checkpoint(tmp_path, 5)
+        incomplete = tmp_path / "full_state_checkpoints" / "step_100"
+        incomplete.mkdir(parents=True)
+        assert find_latest_full_state_checkpoint(tmp_path) == str(valid)
+
+    def test_skips_non_step_directories(self, tmp_path):
+        valid = self._make_checkpoint(tmp_path, 10)
+        other = tmp_path / "full_state_checkpoints" / "not_a_step"
+        other.mkdir(parents=True)
+        torch.save({}, other / "training_state.pt")
+        assert find_latest_full_state_checkpoint(tmp_path) == str(valid)

--- a/tests/test_full_state_checkpoint.py
+++ b/tests/test_full_state_checkpoint.py
@@ -337,3 +337,10 @@ class TestFindLatestFullStateCheckpoint:
         other.mkdir(parents=True)
         torch.save({}, other / "training_state.pt")
         assert find_latest_full_state_checkpoint(tmp_path) == str(valid)
+
+    def test_skips_non_numeric_step_suffix(self, tmp_path):
+        valid = self._make_checkpoint(tmp_path, 7)
+        malformed = tmp_path / "full_state_checkpoints" / "step_latest"
+        malformed.mkdir(parents=True)
+        torch.save({}, malformed / "training_state.pt")
+        assert find_latest_full_state_checkpoint(tmp_path) == str(valid)


### PR DESCRIPTION
## Summary
- Adds `find_latest_full_state_checkpoint()` to scan `{output_dir}/full_state_checkpoints/` for the latest valid `step_*` directory containing `training_state.pt`
- When `on_demand_checkpointing=True` and no explicit `resume_from_full_state_checkpoint` is provided, auto-detects and resumes from the latest checkpoint — matching SFT's auto-resume behavior
- `resume_from_full_state_checkpoint` still works as an explicit override when provided

## Test plan
- [x] 6 new unit tests for `find_latest_full_state_checkpoint()` covering: no dir, empty dir, single checkpoint, multiple checkpoints (picks latest), incomplete checkpoints (skipped), non-step directories (skipped)
- [x] All 23 tests pass (17 existing + 6 new)
- [x] ruff format and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-resume: training will automatically detect and resume from the latest valid full-state checkpoint when on-demand checkpointing is enabled and no resume path is provided.

* **Tests**
  * Added tests covering checkpoint detection, selection of the latest valid checkpoint, and handling of missing or invalid checkpoint entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->