### PR TITLE
Add AI Research Skills plugins to Claude Code action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -90,8 +90,32 @@ jobs:
             feature-dev@claude-plugins-official
             huggingface-skills@claude-plugins-official
             frontend-design@claude-plugins-official
+            model-architecture@ai-research-skills
+            tokenization@ai-research-skills
+            fine-tuning@ai-research-skills
+            mechanistic-interpretability@ai-research-skills
+            data-processing@ai-research-skills
+            post-training@ai-research-skills
+            safety-alignment@ai-research-skills
+            distributed-training@ai-research-skills
+            infrastructure@ai-research-skills
+            optimization@ai-research-skills
+            evaluation@ai-research-skills
+            inference-serving@ai-research-skills
+            mlops@ai-research-skills
+            agents@ai-research-skills
+            rag@ai-research-skills
+            prompt-engineering@ai-research-skills
+            observability@ai-research-skills
+            multimodal@ai-research-skills
+            emerging-techniques@ai-research-skills
+            autoresearch@ai-research-skills
+            ml-paper-writing@ai-research-skills
+            ideation@ai-research-skills
+            agent-native-research-artifact@ai-research-skills
           plugin_marketplaces: |
             https://github.com/anthropics/claude-plugins-official.git
+            https://github.com/Orchestra-Research/AI-research-SKILLs.git
         env:
           ANTHROPIC_VERTEX_PROJECT_ID: ${{ secrets.GCP_PROJECT }}
           CLOUD_ML_REGION: ${{ secrets.GCP_REGION }}


### PR DESCRIPTION
## Summary

Adds 23 AI Research Skills plugin categories from [Orchestra Research](https://github.com/Orchestra-Research/AI-research-SKILLs) to the Claude Code GitHub Action, providing 98 specialized AI/ML research skills across:

- **Model development**: model-architecture, tokenization, fine-tuning, post-training, distributed-training
- **Optimization & serving**: optimization, inference-serving, infrastructure
- **Safety & interpretability**: safety-alignment, mechanistic-interpretability
- **Data & evaluation**: data-processing, evaluation, mlops, observability
- **Applications**: agents, rag, prompt-engineering, multimodal
- **Research workflows**: autoresearch, ml-paper-writing, ideation, agent-native-research-artifact
- **Advanced techniques**: emerging-techniques

### Changes

- Added 23 `ai-research-skills` plugins to the `plugins` list
- Added the Orchestra Research marketplace URL to `plugin_marketplaces`