### PR TITLE
[Feat] torch compile per block for SFT

### DIFF
--- a/src/mini_trainer/api_train.py
+++ b/src/mini_trainer/api_train.py
@@ -167,6 +167,9 @@ def run_training(torch_args: TorchrunArgs, train_args: TrainingArgs) -> None:
         command.append(f"--min-samples-per-checkpoint={train_args.min_samples_per_checkpoint}")
 
     # Add optional boolean flags
+    if train_args.compile_model:
+        command.append("--compile-model")
+
     if train_args.use_liger_kernels:
         command.append("--use-liger-kernels")
 

--- a/src/mini_trainer/sampler.py
+++ b/src/mini_trainer/sampler.py
@@ -503,6 +503,7 @@ def padded_mb_collate_fn(minibatch: list[dict], batch_num_loss_counted_tokens: i
         }
 
     max_len = max(len(item["input_ids"]) for item in minibatch)
+    max_len = (max_len + 7) & ~7  # round up to multiple of 8 for torch.compile
 
     padded_input_ids = []
     padded_labels = []

--- a/src/mini_trainer/sampler.py
+++ b/src/mini_trainer/sampler.py
@@ -455,6 +455,12 @@ def mb_collate_fn(minibatch, batch_num_loss_counted_tokens):
     #     f"num_loss_counted_tokens: {num_loss_counted_tokens}\033[0m"
     # )
 
+    pad_len = (8 - total_len % 8) % 8
+    if pad_len > 0:
+        input_ids.extend([0] * pad_len)
+        labels.extend([-100] * pad_len)
+        position_ids.extend(range(pad_len))
+
     return {
         "input_ids": torch.tensor([input_ids], dtype=torch.long),
         "labels": torch.tensor([labels], dtype=torch.long),

--- a/src/mini_trainer/setup_model_for_training.py
+++ b/src/mini_trainer/setup_model_for_training.py
@@ -484,14 +484,6 @@ def wrap_fsdp2(model: torch.nn.Module, compile_model: bool = False) -> torch.nn.
 
     # Apply torch.compile to each block (after AC, before FSDP2)
     if compile_model:
-        class_name = model.__class__.__name__
-        moe_classes = ("MixtralForCausalLM", "GraniteMoeHybridForCausalLM")
-        if class_name in moe_classes:
-            raise ValueError(
-                f"--compile-model is not compatible with MoE architecture {class_name}. "
-                "MoE router logic causes graph breaks with fullgraph=True."
-            )
-        torch._dynamo.config.skip_fwd_side_effects_in_bwd_under_checkpoint = True
         log_rank_0(f"🔄 [Phase 2] Compiling {len(layers)} transformer blocks with torch.compile")
         for idx, block in enumerate(layers):
             layers[idx] = torch.compile(block, backend="inductor", fullgraph=True)

--- a/src/mini_trainer/setup_model_for_training.py
+++ b/src/mini_trainer/setup_model_for_training.py
@@ -486,7 +486,7 @@ def wrap_fsdp2(model: torch.nn.Module, compile_model: bool = False) -> torch.nn.
     if compile_model:
         log_rank_0(f"🔄 [Phase 2] Compiling {len(layers)} transformer blocks with torch.compile")
         for idx, block in enumerate(layers):
-            layers[idx] = torch.compile(block, backend="inductor", fullgraph=True)
+            layers[idx] = torch.compile(block, fullgraph=True, dynamic=True)
 
     # Build 1D device mesh over all ranks
     world_size = dist.get_world_size()

--- a/src/mini_trainer/setup_model_for_training.py
+++ b/src/mini_trainer/setup_model_for_training.py
@@ -415,7 +415,7 @@ def prepare_model_for_fsdp2(model: torch.nn.Module) -> ModelInitializationContex
     return context
 
 
-def wrap_fsdp2(model: torch.nn.Module) -> torch.nn.Module:
+def wrap_fsdp2(model: torch.nn.Module, compile_model: bool = False) -> torch.nn.Module:
     """
     Phase 2: Pure FSDP2 wrapping with activation checkpointing.
 
@@ -481,6 +481,20 @@ def wrap_fsdp2(model: torch.nn.Module) -> torch.nn.Module:
         for idx, block in enumerate(layers):
             # preserve_rng_state needs to be true so that the backward pass can be accurate
             layers[idx] = ptd_checkpoint_wrapper(block, preserve_rng_state=True)
+
+    # Apply torch.compile to each block (after AC, before FSDP2)
+    if compile_model:
+        class_name = model.__class__.__name__
+        moe_classes = ("MixtralForCausalLM", "GraniteMoeHybridForCausalLM")
+        if class_name in moe_classes:
+            raise ValueError(
+                f"--compile-model is not compatible with MoE architecture {class_name}. "
+                "MoE router logic causes graph breaks with fullgraph=True."
+            )
+        torch._dynamo.config.skip_fwd_side_effects_in_bwd_under_checkpoint = True
+        log_rank_0(f"🔄 [Phase 2] Compiling {len(layers)} transformer blocks with torch.compile")
+        for idx, block in enumerate(layers):
+            layers[idx] = torch.compile(block, backend="inductor", fullgraph=True)
 
     # Build 1D device mesh over all ranks
     world_size = dist.get_world_size()
@@ -1262,11 +1276,6 @@ def setup_model(
             to_print=True,
         )
 
-    # NOTE: Don't enable HuggingFace gradient checkpointing with FSDP2
-    # It causes conflicts. TorchTitan applies PyTorch's checkpoint wrapper
-    # BEFORE FSDP2 wrapping if needed.
-    # model.gradient_checkpointing_enable()
-    # torch.compile(model)
     return model
 
 
@@ -1283,13 +1292,14 @@ def setup_training_components(
     eps: float = 1e-8,
     weight_decay: float = 0.0,
     resume_from_checkpoint: str | None = None,
+    compile_model: bool = False,
 ) -> tuple[torch.nn.Module, torch.optim.Optimizer, torch.optim.lr_scheduler.LRScheduler]:
     """
     Set up training components including model wrapping, optimizer, and learning rate scheduler.
 
     This function orchestrates the three-phase model initialization pipeline:
     1. Phase 1: Prepare model for FSDP2 (extract state dicts, materialize buffers)
-    2. Phase 2: Pure FSDP2 wrapping (activation checkpointing + sharding)
+    2. Phase 2: Pure FSDP2 wrapping (activation checkpointing + compilation + sharding)
     3. Phase 3: Finalize initialization (distribute weights, compute SVD for OSFT)
 
     Args:
@@ -1299,6 +1309,7 @@ def setup_training_components(
         lr_scheduler: Type of learning rate scheduler to use
         num_training_steps: Total number of training steps (required for some schedulers)
         scheduler_kwargs: Additional scheduler-specific keyword arguments
+        compile_model: Whether to compile transformer blocks with torch.compile
 
     Returns:
         Tuple of (wrapped_model, optimizer, lr_scheduler)
@@ -1313,8 +1324,8 @@ def setup_training_components(
     init_context = prepare_model_for_fsdp2(model)
     init_context.resume_from_checkpoint = resume_from_checkpoint
 
-    # Phase 2: Pure FSDP2 wrapping
-    model = wrap_fsdp2(model)
+    # Phase 2: Pure FSDP2 wrapping (+ optional compilation)
+    model = wrap_fsdp2(model, compile_model=compile_model)
 
     # Phase 3: Finalize model initialization (distribute weights)
     model = finalize_model_initialization(model, init_context)

--- a/src/mini_trainer/setup_model_for_training.py
+++ b/src/mini_trainer/setup_model_for_training.py
@@ -427,6 +427,8 @@ def wrap_fsdp2(model: torch.nn.Module, compile_model: bool = False) -> torch.nn.
 
     Args:
         model: Model to wrap with FSDP2 (should already have buffers materialized)
+        compile_model: If True, compile each transformer block with torch.compile
+            (fullgraph=True, dynamic=True) between AC wrapping and FSDP2 sharding.
 
     Returns:
         FSDP2-wrapped model

--- a/src/mini_trainer/train.py
+++ b/src/mini_trainer/train.py
@@ -1283,6 +1283,7 @@ def main(
     beta2: Annotated[float, Option(help="AdamW beta2 parameter (RMSprop coefficient)")] = 0.95,
     eps: Annotated[float, Option(help="AdamW epsilon for numerical stability")] = 1e-8,
     weight_decay: Annotated[float, Option(help="AdamW weight decay (L2 penalty)")] = 0.0,
+    compile_model: Annotated[bool, Option(help="Compile transformer blocks with torch.compile")] = False,
     use_liger_kernels: Annotated[bool, Option(help="Whether to use Liger kernels")] = False,
     osft: Annotated[bool, Option(help="Enable OSFT (Orthogonal Subspace Fine-Tuning)")] = False,
     osft_unfreeze_rank_ratio: Annotated[
@@ -1406,6 +1407,12 @@ def main(
 
     # validation, do this before continuing execution flow so we don't log experiments that are invalid from
     # the get-go
+    if compile_model and osft:
+        raise ValueError(
+            "--compile-model is not compatible with --osft. "
+            "OSFT uses dynamic forward methods that cannot be traced by torch.compile."
+        )
+
     if osft:
         if osft_unfreeze_rank_ratio is None:
             raise ValueError("osft_unfreeze_rank_ratio is required when osft is True")
@@ -1613,6 +1620,7 @@ def main(
         eps=eps,
         weight_decay=weight_decay,
         resume_from_checkpoint=resume_from_full_state_checkpoint,
+        compile_model=compile_model,
     )
 
     # Reconstruct callbacks from serialized CLI arg

--- a/src/mini_trainer/train.py
+++ b/src/mini_trainer/train.py
@@ -363,9 +363,6 @@ def compute_validation_loss(model, val_data_loader, device):
                 loss = output.loss.float().sum()
                 loss_metrics = loss.detach().item()
 
-                # Clear cache after each minibatch to prevent OOM
-                torch.cuda.empty_cache()
-
                 val_batch_totals.accumulate_minibatch_metrics(
                     num_loss_counted_tokens=mb_num_loss_counted_tokens,
                     num_total_tokens=mb["input_ids"].numel(),
@@ -943,23 +940,19 @@ def train(
 
                 # Ensure scalar loss even if model returns per-token loss
                 loss = (loss / batch_num_loss_counted_tokens) * world_size
-                loss_metrics = loss.detach().cpu().item()
+                loss_metrics = loss.detach().item()
                 loss.backward()
 
                 if callback_manager and callback_manager.has_callbacks("on_after_backward"):
                     callback_manager.context.loss = loss_metrics
                     callback_manager.fire("on_after_backward")
 
-                torch.cuda.empty_cache()
-
                 batch_totals.accumulate_minibatch_metrics(
                     num_loss_counted_tokens=mb_num_loss_counted_tokens,
                     num_total_tokens=mb["input_ids"].shape[1],
                     num_samples=mb_num_samples,
                     loss=loss_metrics,
-                    # since FSDP2 automatically averages gradients by the world-size,
-                    # each rank's gradient contributes 1/8 to the backward
-                    loss_backward=loss.detach().item() / world_size,
+                    loss_backward=loss_metrics / world_size,
                     time_per_minibatch=time.time() - mb_start_time,
                 )
 
@@ -1075,6 +1068,15 @@ def train(
                 metric_logger.log_sync(batch_metrics)
 
             dist.barrier()
+
+            if step == 1 and is_local_main_process:
+                peak_gb = batch_metrics["peak_memory_usage_GB"]
+                gpu_total_gb = torch.cuda.get_device_properties(device).total_memory / 1e9
+                utilization = peak_gb / gpu_total_gb
+                log_rank_0(
+                    f"Memory after step 1: {peak_gb:.1f}GB / {gpu_total_gb:.1f}GB "
+                    f"({utilization:.0%} utilization)"
+                )
 
             # On-demand full-state checkpoint check
             if full_state_checkpointer is not None and full_state_checkpointer.should_save(device):

--- a/src/mini_trainer/train.py
+++ b/src/mini_trainer/train.py
@@ -1590,6 +1590,7 @@ def main(
         # future versions where AC's RNG side effects cause graph breaks.
         # See test_compile_works_without_dynamo_config_flag.
         torch._dynamo.config.skip_fwd_side_effects_in_bwd_under_checkpoint = True
+        torch._inductor.config.unsafe_skip_cache_dynamic_shape_guards = True
 
     # Create PretrainingConfig if block_size is provided
     pretraining_config = None

--- a/src/mini_trainer/train.py
+++ b/src/mini_trainer/train.py
@@ -1413,6 +1413,12 @@ def main(
             "OSFT uses dynamic forward methods that cannot be traced by torch.compile."
         )
 
+    if compile_model and use_liger_kernels:
+        raise ValueError(
+            "--compile-model is not compatible with --use-liger-kernels. "
+            "Both replace the same memory-bound ops; the interaction is untested."
+        )
+
     if osft:
         if osft_unfreeze_rank_ratio is None:
             raise ValueError("osft_unfreeze_rank_ratio is required when osft is True")
@@ -1570,6 +1576,15 @@ def main(
                             )
                             model.resize_token_embeddings(ckpt_embed_size)
                     break
+
+    if compile_model:
+        moe_classes = ("MixtralForCausalLM", "GraniteMoeHybridForCausalLM")
+        if model.__class__.__name__ in moe_classes:
+            raise ValueError(
+                f"--compile-model is not compatible with MoE architecture {model.__class__.__name__}. "
+                "MoE router logic causes graph breaks with fullgraph=True."
+            )
+        torch._dynamo.config.skip_fwd_side_effects_in_bwd_under_checkpoint = True
 
     # Create PretrainingConfig if block_size is provided
     pretraining_config = None

--- a/src/mini_trainer/train.py
+++ b/src/mini_trainer/train.py
@@ -1584,6 +1584,7 @@ def main(
                 f"--compile-model is not compatible with MoE architecture {model.__class__.__name__}. "
                 "MoE router logic causes graph breaks with fullgraph=True."
             )
+        # Without this, AC's RNG side effects cause a graph break under compile.
         torch._dynamo.config.skip_fwd_side_effects_in_bwd_under_checkpoint = True
 
     # Create PretrainingConfig if block_size is provided

--- a/src/mini_trainer/train.py
+++ b/src/mini_trainer/train.py
@@ -1069,13 +1069,12 @@ def train(
 
             dist.barrier()
 
-            if step == 1 and is_local_main_process:
+            if step == 1 and is_local_main_process and torch.cuda.is_available():
                 peak_gb = batch_metrics["peak_memory_usage_GB"]
                 gpu_total_gb = torch.cuda.get_device_properties(device).total_memory / 1e9
                 utilization = peak_gb / gpu_total_gb
                 log_rank_0(
-                    f"Memory after step 1: {peak_gb:.1f}GB / {gpu_total_gb:.1f}GB "
-                    f"({utilization:.0%} utilization)"
+                    f"Memory after step 1: {peak_gb:.1f}GB / {gpu_total_gb:.1f}GB ({utilization:.0%} utilization)"
                 )
 
             # On-demand full-state checkpoint check

--- a/src/mini_trainer/train.py
+++ b/src/mini_trainer/train.py
@@ -1584,7 +1584,9 @@ def main(
                 f"--compile-model is not compatible with MoE architecture {model.__class__.__name__}. "
                 "MoE router logic causes graph breaks with fullgraph=True."
             )
-        # Without this, AC's RNG side effects cause a graph break under compile.
+        # Defensive: not required on current PyTorch but may be needed on
+        # future versions where AC's RNG side effects cause graph breaks.
+        # See test_compile_works_without_dynamo_config_flag.
         torch._dynamo.config.skip_fwd_side_effects_in_bwd_under_checkpoint = True
 
     # Create PretrainingConfig if block_size is provided

--- a/src/mini_trainer/training_types.py
+++ b/src/mini_trainer/training_types.py
@@ -96,6 +96,15 @@ class TrainingArgs:
     )
     weight_decay: float = field(default=0.0, metadata={"help": "Weight decay (L2 penalty) for AdamW optimizer."})
 
+    # Compilation
+    compile_model: bool = field(
+        default=False,
+        metadata={
+            "help": "Compile transformer blocks with torch.compile for improved throughput. "
+            "Not compatible with OSFT or MoE architectures."
+        },
+    )
+
     # Model configuration
     use_liger_kernels: bool = field(default=False, metadata={"help": "Whether to use Liger kernels."})
     osft: bool = field(

--- a/tests/gpu_tests/test_compile.py
+++ b/tests/gpu_tests/test_compile.py
@@ -1,0 +1,279 @@
+"""GPU tests for per-block torch.compile integration with FSDP2."""
+
+import os
+
+os.environ["TESTING"] = "true"
+
+import gc
+
+import pytest
+import torch
+import torch.distributed as dist
+from transformers import AutoTokenizer, LlamaConfig, LlamaForCausalLM
+
+from mini_trainer.setup_model_for_training import setup_model, setup_training_components
+from mini_trainer.utils import patch_target_module
+
+
+def create_tiny_llama_model():
+    config = LlamaConfig(
+        vocab_size=1000,
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        max_position_embeddings=128,
+        rope_theta=10000.0,
+        hidden_act="silu",
+    )
+    return LlamaForCausalLM(config), config
+
+
+def _run_steps(model_path, compile_model, input_ids, labels, num_steps=3):
+    """Load model, wrap with FSDP2 (± compile), run steps, return losses."""
+    model = setup_model(
+        model_name_or_path=str(model_path),
+        use_liger_kernels=False,
+        osft=False,
+        local_rank=0,
+    )
+    model, optimizer, lr_scheduler = setup_training_components(
+        model,
+        learning_rate=1e-3,
+        num_warmup_steps=0,
+        lr_scheduler="constant",
+        compile_model=compile_model,
+    )
+
+    losses = []
+    for _ in range(num_steps):
+        optimizer.zero_grad()
+        output = model(input_ids=input_ids, labels=labels)
+        loss = output.loss.float().sum() / input_ids.shape[0]
+        loss.backward()
+        torch.nn.utils.clip_grad_norm_(model.parameters(), 1.0)
+        optimizer.step()
+        lr_scheduler.step()
+        losses.append(loss.item())
+
+    return losses, model
+
+
+@pytest.mark.gpu
+class TestCompile:
+    @pytest.fixture(autouse=True, scope="class")
+    def dist_env(self):
+        """Single process group for the entire test class."""
+        os.environ["RANK"] = "0"
+        os.environ["WORLD_SIZE"] = "1"
+        os.environ["LOCAL_RANK"] = "0"
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = "12356"
+        dist.init_process_group(backend="nccl", rank=0, world_size=1)
+
+        from mini_trainer.none_reduction_losses import (
+            hf_fixed_cross_entropy_none_reduction,
+        )
+
+        patch_target_module(
+            "transformers.loss.loss_utils.fixed_cross_entropy",
+            hf_fixed_cross_entropy_none_reduction,
+        )
+
+        yield
+
+        dist.destroy_process_group()
+
+    @pytest.fixture(autouse=True)
+    def reset_dynamo(self):
+        torch._dynamo.reset()
+        torch._dynamo.config.skip_fwd_side_effects_in_bwd_under_checkpoint = False
+        yield
+        torch._dynamo.reset()
+        torch._dynamo.config.skip_fwd_side_effects_in_bwd_under_checkpoint = False
+
+    @pytest.fixture
+    def saved_model(self, tmp_path):
+        """Create and save a tiny Llama model + tokenizer to disk."""
+        torch.manual_seed(42)
+        model, config = create_tiny_llama_model()
+        tokenizer = AutoTokenizer.from_pretrained("gpt2")
+        tokenizer.pad_token = tokenizer.eos_token
+        model_path = tmp_path / "tiny_llama"
+        model.save_pretrained(model_path)
+        tokenizer.save_pretrained(model_path)
+        return model_path, config
+
+    def test_compiled_matches_eager(self, saved_model, single_gpu_device):
+        """Compiled and eager produce approximately equal losses.
+
+        Not exact equality: bf16 mixed precision + inductor kernel fusion
+        reorder floating-point ops, so small divergence is expected.
+        Observed gap is O(1e-3) on loss values O(1e+2), growing across
+        steps as differences accumulate. Tolerance is set at 10x the
+        observed per-step gap.
+        """
+        model_path, config = saved_model
+
+        torch.manual_seed(99)
+        input_ids = torch.randint(0, config.vocab_size, (2, 32), device=single_gpu_device)
+        labels = input_ids.clone()
+
+        # Eager run
+        torch.manual_seed(7)
+        torch.cuda.manual_seed(7)
+        eager_losses, eager_model = _run_steps(model_path, compile_model=False, input_ids=input_ids, labels=labels)
+
+        del eager_model
+        gc.collect()
+        torch.cuda.empty_cache()
+        torch._dynamo.reset()
+
+        # Compiled run (same model weights from disk, same seed)
+        torch.manual_seed(7)
+        torch.cuda.manual_seed(7)
+        torch._dynamo.config.skip_fwd_side_effects_in_bwd_under_checkpoint = True
+        compiled_losses, _ = _run_steps(model_path, compile_model=True, input_ids=input_ids, labels=labels)
+
+        for step, (e, c) in enumerate(zip(eager_losses, compiled_losses)):
+            assert abs(e - c) < 0.1, (
+                f"Step {step}: eager loss {e:.6f} vs compiled loss {c:.6f}, diff {abs(e - c):.2e} exceeds tolerance 0.1"
+            )
+
+    def test_no_graph_breaks_and_dynamic_shapes(self, saved_model, single_gpu_device):
+        """Forward/backward completes under fullgraph=True with varied seq_len.
+
+        Two forward/backward passes with different sequence lengths verify:
+        1. No graph breaks (fullgraph=True contract)
+        2. dynamic=True reuses the same compiled graph (no recompilation)
+        """
+        model_path, config = saved_model
+
+        torch._dynamo.utils.counters.clear()
+        torch._dynamo.config.skip_fwd_side_effects_in_bwd_under_checkpoint = True
+
+        model = setup_model(
+            model_name_or_path=str(model_path),
+            use_liger_kernels=False,
+            osft=False,
+            local_rank=0,
+        )
+        model, optimizer, lr_scheduler = setup_training_components(
+            model,
+            learning_rate=1e-3,
+            num_warmup_steps=0,
+            lr_scheduler="constant",
+            compile_model=True,
+        )
+
+        # Step 1: seq_len=32
+        input_ids_1 = torch.randint(0, config.vocab_size, (2, 32), device=single_gpu_device)
+        optimizer.zero_grad()
+        loss = model(input_ids=input_ids_1, labels=input_ids_1.clone()).loss.float().sum()
+        loss.backward()
+        optimizer.step()
+
+        compilations_after_first = torch._dynamo.utils.counters["stats"]["ok"]
+
+        # Step 2: seq_len=48 (different shape — should reuse graph via dynamic=True)
+        input_ids_2 = torch.randint(0, config.vocab_size, (2, 48), device=single_gpu_device)
+        optimizer.zero_grad()
+        loss = model(input_ids=input_ids_2, labels=input_ids_2.clone()).loss.float().sum()
+        loss.backward()
+        optimizer.step()
+
+        compilations_after_second = torch._dynamo.utils.counters["stats"]["ok"]
+
+        graph_breaks = dict(torch._dynamo.utils.counters["graph_break"])
+        assert len(graph_breaks) == 0, f"Graph breaks detected: {graph_breaks}"
+
+        assert compilations_after_second == compilations_after_first, (
+            f"dynamic=True should prevent recompilation on shape change, "
+            f"but compilations went from {compilations_after_first} to {compilations_after_second}"
+        )
+
+    def test_optimized_module_wrappers(self, saved_model, single_gpu_device):
+        """Compiled blocks are OptimizedModule; uncompiled blocks are not."""
+        model_path, _ = saved_model
+
+        # Compiled path
+        torch._dynamo.config.skip_fwd_side_effects_in_bwd_under_checkpoint = True
+        model_c = setup_model(
+            model_name_or_path=str(model_path),
+            use_liger_kernels=False,
+            osft=False,
+            local_rank=0,
+        )
+        model_c, _, _ = setup_training_components(
+            model_c,
+            learning_rate=1e-3,
+            num_warmup_steps=0,
+            lr_scheduler="constant",
+            compile_model=True,
+        )
+
+        from torch._dynamo.eval_frame import OptimizedModule
+
+        layers_c = model_c.model.layers
+        for idx, block in enumerate(layers_c):
+            assert isinstance(block, OptimizedModule), f"Block {idx} should be OptimizedModule, got {type(block)}"
+
+        del model_c
+        gc.collect()
+        torch.cuda.empty_cache()
+
+        # Eager path
+        model_e = setup_model(
+            model_name_or_path=str(model_path),
+            use_liger_kernels=False,
+            osft=False,
+            local_rank=0,
+        )
+        model_e, _, _ = setup_training_components(
+            model_e,
+            learning_rate=1e-3,
+            num_warmup_steps=0,
+            lr_scheduler="constant",
+            compile_model=False,
+        )
+
+        layers_e = model_e.model.layers
+        for idx, block in enumerate(layers_e):
+            assert not isinstance(block, OptimizedModule), (
+                f"Block {idx} should NOT be OptimizedModule, got {type(block)}"
+            )
+
+    def test_compile_works_without_dynamo_config_flag(self, saved_model, single_gpu_device):
+        """AC + compile works without skip_fwd_side_effects_in_bwd_under_checkpoint.
+
+        The flag is set defensively in train.py but is not required on current
+        PyTorch. If this test starts failing on a future version, the flag
+        becomes load-bearing and the comment in train.py should be updated.
+        """
+        model_path, config = saved_model
+
+        torch._dynamo.config.skip_fwd_side_effects_in_bwd_under_checkpoint = False
+
+        model = setup_model(
+            model_name_or_path=str(model_path),
+            use_liger_kernels=False,
+            osft=False,
+            local_rank=0,
+        )
+        model, optimizer, _ = setup_training_components(
+            model,
+            learning_rate=1e-3,
+            num_warmup_steps=0,
+            lr_scheduler="constant",
+            compile_model=True,
+        )
+
+        input_ids = torch.randint(0, config.vocab_size, (2, 32), device=single_gpu_device)
+        labels = input_ids.clone()
+
+        optimizer.zero_grad()
+        output = model(input_ids=input_ids, labels=labels)
+        loss = output.loss.float().sum()
+        loss.backward()
+        optimizer.step()

--- a/tests/test_api_train.py
+++ b/tests/test_api_train.py
@@ -748,6 +748,7 @@ sys.exit(1)
                 max_tokens_per_gpu=1000,
                 learning_rate=1e-5,
                 output_dir=tmpdir,
+                compile_model=True,
                 use_liger_kernels=True,
                 checkpoint_at_epoch=True,
                 save_final_checkpoint=True,
@@ -767,6 +768,7 @@ sys.exit(1)
                 _, command = call_args[0]
 
                 # Verify all boolean flags are present
+                assert "--compile-model" in command
                 assert "--use-liger-kernels" in command
                 assert "--osft" in command
                 assert "--checkpoint-at-epoch" in command
@@ -783,6 +785,7 @@ sys.exit(1)
                 max_tokens_per_gpu=1000,
                 learning_rate=1e-5,
                 output_dir=tmpdir,
+                compile_model=False,
                 use_liger_kernels=False,
                 osft=False,
                 checkpoint_at_epoch=False,
@@ -800,6 +803,7 @@ sys.exit(1)
                 _, command = call_args[0]
 
                 # Verify boolean flags are NOT present when False
+                assert "--compile-model" not in command
                 assert "--use-liger-kernels" not in command
                 assert "--osft" not in command
                 assert "--checkpoint-at-epoch" not in command

--- a/tests/test_compile_guards.py
+++ b/tests/test_compile_guards.py
@@ -1,0 +1,51 @@
+"""Unit tests for torch.compile validation guard contracts.
+
+These tests document the expected guard behavior from train.py:main().
+They test the guard conditions directly (not via main()) because main()
+requires a full distributed environment. The GPU tests in
+gpu_tests/test_compile.py exercise the real code path end-to-end.
+"""
+
+import pytest
+
+
+class TestCompileValidationGuards:
+    def test_compile_osft_incompatible(self):
+        compile_model = True
+        osft = True
+        with pytest.raises(ValueError, match="not compatible with --osft"):
+            if compile_model and osft:
+                raise ValueError(
+                    "--compile-model is not compatible with --osft. "
+                    "OSFT uses dynamic forward methods that cannot be traced by torch.compile."
+                )
+
+    def test_compile_liger_incompatible(self):
+        compile_model = True
+        use_liger_kernels = True
+        with pytest.raises(ValueError, match="not compatible with --use-liger-kernels"):
+            if compile_model and use_liger_kernels:
+                raise ValueError(
+                    "--compile-model is not compatible with --use-liger-kernels. "
+                    "Both replace the same memory-bound ops; the interaction is untested."
+                )
+
+    def test_compile_moe_incompatible(self):
+        moe_classes = ("MixtralForCausalLM", "GraniteMoeHybridForCausalLM")
+        for cls_name in moe_classes:
+            with pytest.raises(ValueError, match="not compatible with MoE"):
+                if cls_name in moe_classes:
+                    raise ValueError(
+                        f"--compile-model is not compatible with MoE architecture {cls_name}. "
+                        "MoE router logic causes graph breaks with fullgraph=True."
+                    )
+
+    def test_compile_guards_do_not_fire_when_disabled(self):
+        compile_model = False
+        osft = True
+        use_liger_kernels = True
+
+        if compile_model and osft:
+            raise ValueError("should not reach")
+        if compile_model and use_liger_kernels:
+            raise ValueError("should not reach")

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -132,10 +132,10 @@ class TestMbCollateFn:
 
         result = mb_collate_fn(minibatch, batch_num_loss_counted_tokens=4)
 
-        assert result["input_ids"].shape == (1, 5)
-        assert result["labels"].shape == (1, 5)
-        assert result["position_ids"].shape == (1, 5)
-        assert result["position_ids"].tolist() == [[0, 1, 2, 3, 4]]
+        assert result["input_ids"].shape == (1, 8)
+        assert result["labels"].shape == (1, 8)
+        assert result["position_ids"].shape == (1, 8)
+        assert result["position_ids"].tolist() == [[0, 1, 2, 3, 4, 0, 1, 2]]
         assert result["num_loss_counted_tokens"] == 4
         assert result["num_samples"] == 1
         assert result["batch_num_loss_counted_tokens"] == 4
@@ -157,13 +157,13 @@ class TestMbCollateFn:
 
         result = mb_collate_fn(minibatch, batch_num_loss_counted_tokens=6)
 
-        # Check concatenation
-        assert result["input_ids"].shape == (1, 7)
-        assert result["input_ids"].tolist() == [[1, 2, 3, 4, 5, 6, 7]]
-        assert result["labels"].tolist() == [[10, 20, 30, 40, -100, 60, 70]]
+        # Check concatenation (padded to mod-8)
+        assert result["input_ids"].shape == (1, 8)
+        assert result["input_ids"].tolist() == [[1, 2, 3, 4, 5, 6, 7, 0]]
+        assert result["labels"].tolist() == [[10, 20, 30, 40, -100, 60, 70, -100]]
 
-        # Check position_ids reset for each sequence
-        assert result["position_ids"].tolist() == [[0, 1, 2, 0, 1, 2, 3]]
+        # Check position_ids reset for each sequence (pad token starts new mini-sequence)
+        assert result["position_ids"].tolist() == [[0, 1, 2, 0, 1, 2, 3, 0]]
 
         assert result["num_loss_counted_tokens"] == 6
         assert result["num_samples"] == 2

--- a/tests/test_model_initialization.py
+++ b/tests/test_model_initialization.py
@@ -297,7 +297,7 @@ class TestSetupTrainingComponents:
         assert lr_scheduler == mock_lr_scheduler
 
         # Check FSDP2 wrapping
-        mock_wrap.assert_called_once_with(mock_model)
+        mock_wrap.assert_called_once_with(mock_model, compile_model=False)
 
         # Check optimizer creation
         mock_adamw.assert_called_once_with(

--- a/tests/test_training_loop.py
+++ b/tests/test_training_loop.py
@@ -949,7 +949,6 @@ class TestMemoryManagement:
 
         # Verify memory management calls
         mock_reset_stats.assert_called()
-        mock_empty_cache.assert_called()
 
         # Verify memory was tracked in metrics
         logged_metrics = mock_logger.log_sync.call_args[0][0]


### PR DESCRIPTION
Compile each transformer block with torch.compile(fullgraph=True)
following torchtitan's AC -> compile -> FSDP2 ordering.

Preliminary results. 
Benchmarked on 8x H200 (SDPA, BF16, batch=4, 2048 tok/GPU):
  Qwen3-4B:   4,184 -> 6,008 tok/s (+44%)
  Granite-8B: 3,227 -> 3,708 tok/s (+15%)

Not compatible with OSFT (graph breaks from closure-based forwards)
or MoE architectures (router logic breaks fullgraph). 

I'm curious to see what the testing/benchmarking shows!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `--compile-model` option to compile supported transformer blocks during training.
  * Added validation to prevent incompatible combinations with OSFT, Liger kernels, and supported MoE architectures.

* **Performance & Reliability**
  * Improved minibatch padding by aligning token lengths to multiples of 8.
  * Updated training metrics and memory handling, including one-time GPU memory reporting.

* **Tests**
  * Expanded coverage for model compilation, validation safeguards, padding, and command-line options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->