### PR TITLE
Pass train_dtype into _load_model_memory_efficient (MT-2)

### DIFF
--- a/src/mini_trainer/osft_utils.py
+++ b/src/mini_trainer/osft_utils.py
@@ -913,6 +913,7 @@ def _load_model_memory_efficient(
     model_args: tuple,
     base_kwargs: dict,
     osft_class_kwargs: dict,
+    train_dtype: "torch.dtype | None" = None,
 ):
     """
     Memory-efficient loading for OSFT models to avoid CUDA/CPU OOM.
@@ -927,8 +928,8 @@ def _load_model_memory_efficient(
         pretrained_model_name_or_path: Model path or name
         model_args: Positional arguments for model loading
         base_kwargs: Base model kwargs (already filtered)
-        init_cfg: OSFT configuration
         osft_class_kwargs: OSFT class-specific parameters
+        train_dtype: Explicit training dtype for model loading
 
     Returns:
         Loaded OSFT model
@@ -952,9 +953,8 @@ def _load_model_memory_efficient(
     # Remove additional OSFT parameters before calling base model's from_pretrained
     final_base_kwargs = _filter_osft_parameters(base_kwargs, OSFT_BASE_MODEL_FILTERED_PARAMS)
 
-    # Force CPU loading via default behavior and match the train_dtype for FSDP2
-    # Need to get train_dtype from base_kwargs or default to float32
-    load_dtype = base_kwargs.get("torch_dtype")
+    # Use the explicit train_dtype when provided, fall back to base_kwargs for FSDP2
+    load_dtype = train_dtype if train_dtype is not None else base_kwargs.get("torch_dtype")
     if load_dtype is None:
         raise ValueError("error: model does not have a `torch_dtype` setting, please report this to the developers")
     final_base_kwargs["torch_dtype"] = load_dtype
@@ -1334,6 +1334,7 @@ def create_osft_model_class(base_cls) -> type[OSFTModel]:
                     model_args,
                     base_kwargs,
                     osft_class_kwargs,
+                    train_dtype=base_kwargs.get("torch_dtype"),
                 )
             else:
                 # standard non-distributed loading

--- a/src/mini_trainer/osft_utils.py
+++ b/src/mini_trainer/osft_utils.py
@@ -913,7 +913,7 @@ def _load_model_memory_efficient(
     model_args: tuple,
     base_kwargs: dict,
     osft_class_kwargs: dict,
-    train_dtype: "torch.dtype | None" = None,
+    train_dtype: torch.dtype | None = None,
 ):
     """
     Memory-efficient loading for OSFT models to avoid CUDA/CPU OOM.

--- a/tests/test_osft.py
+++ b/tests/test_osft.py
@@ -2204,6 +2204,110 @@ class TestLazyInitTokenizerAlignment:
         assert align_mock.call_count == 1
         assert loaded_models and loaded_models[0].aligned is True
 
+    def test_memory_efficient_loading_fallback_when_train_dtype_is_none(self, monkeypatch):
+        """When train_dtype is None, load_dtype should fall back to base_kwargs['torch_dtype']."""
+
+        class DummyLoadedModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.config = MagicMock()
+                self.config.vocab_size = 10
+                self.aligned = False
+
+            def state_dict(self):
+                return {"weight": torch.zeros(1)}
+
+            def named_buffers(self):
+                return [("buffer", torch.zeros(1))]
+
+        captured_kwargs = {}
+
+        class DummyBase(nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            @classmethod
+            def from_pretrained(cls, *args, **kwargs):
+                captured_kwargs.update(kwargs)
+                return DummyLoadedModel()
+
+        class DummyOSFT(DummyBase):
+            def __init__(self, config, **kwargs):
+                super().__init__()
+                self.config = config
+                self._lazy_init_pending = True
+
+        monkeypatch.setattr(osft_module.dist, "is_available", lambda: True)
+        monkeypatch.setattr(osft_module.dist, "is_initialized", lambda: True)
+        monkeypatch.setattr(osft_module.dist, "get_rank", lambda: 0)
+        monkeypatch.setattr(osft_module.dist, "barrier", lambda: None)
+        monkeypatch.setattr(osft_module.dist, "broadcast_object_list", lambda *_, **__: None)
+        monkeypatch.setattr(osft_module.torch.cuda, "is_available", lambda: False)
+
+        model = _load_model_memory_efficient(
+            actual_osft_cls=DummyOSFT,
+            pretrained_model_name_or_path="dummy",
+            model_args=tuple(),
+            base_kwargs={"torch_dtype": torch.bfloat16},
+            osft_class_kwargs={},
+            train_dtype=None,
+        )
+
+        assert isinstance(model, DummyOSFT)
+        assert captured_kwargs["torch_dtype"] == torch.bfloat16
+
+    def test_memory_efficient_loading_train_dtype_overrides_base_kwargs(self, monkeypatch):
+        """When train_dtype differs from base_kwargs['torch_dtype'], train_dtype takes precedence."""
+
+        class DummyLoadedModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.config = MagicMock()
+                self.config.vocab_size = 10
+                self.aligned = False
+
+            def state_dict(self):
+                return {"weight": torch.zeros(1)}
+
+            def named_buffers(self):
+                return [("buffer", torch.zeros(1))]
+
+        captured_kwargs = {}
+
+        class DummyBase(nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            @classmethod
+            def from_pretrained(cls, *args, **kwargs):
+                captured_kwargs.update(kwargs)
+                return DummyLoadedModel()
+
+        class DummyOSFT(DummyBase):
+            def __init__(self, config, **kwargs):
+                super().__init__()
+                self.config = config
+                self._lazy_init_pending = True
+
+        monkeypatch.setattr(osft_module.dist, "is_available", lambda: True)
+        monkeypatch.setattr(osft_module.dist, "is_initialized", lambda: True)
+        monkeypatch.setattr(osft_module.dist, "get_rank", lambda: 0)
+        monkeypatch.setattr(osft_module.dist, "barrier", lambda: None)
+        monkeypatch.setattr(osft_module.dist, "broadcast_object_list", lambda *_, **__: None)
+        monkeypatch.setattr(osft_module.torch.cuda, "is_available", lambda: False)
+
+        model = _load_model_memory_efficient(
+            actual_osft_cls=DummyOSFT,
+            pretrained_model_name_or_path="dummy",
+            model_args=tuple(),
+            base_kwargs={"torch_dtype": torch.float32},
+            osft_class_kwargs={},
+            train_dtype=torch.bfloat16,
+        )
+
+        assert isinstance(model, DummyOSFT)
+        assert captured_kwargs["torch_dtype"] == torch.bfloat16
+
 
 class TestPostStepParameterProjection:
     """Test post-step parameter re-projection to fix AdamW subspace leak.

--- a/tests/test_osft.py
+++ b/tests/test_osft.py
@@ -2197,6 +2197,7 @@ class TestLazyInitTokenizerAlignment:
             model_args=tuple(),
             base_kwargs={"torch_dtype": torch.float32},
             osft_class_kwargs={"lazy_init_tokenizer_align_fn": align_mock},
+            train_dtype=torch.float32,
         )
 
         assert isinstance(model, DummyOSFT)


### PR DESCRIPTION
## Summary

- Adds explicit `train_dtype` parameter to `_load_model_memory_efficient()` instead of deriving it from `base_kwargs["torch_dtype"]` internally
- Falls back to `base_kwargs.get("torch_dtype")` when `train_dtype` is not provided, maintaining backward compatibility
- Updates call site in `from_pretrained()` to pass `train_dtype=base_kwargs.get("torch_dtype")`
- Updates test to pass `train_dtype` explicitly

Closes #34

## Test plan

- [x] Ruff lint passes
- [x] Ruff format passes
- [ ] Non-GPU unit tests pass (requires Python >=3.11)
- [ ] GPU tests on A100 to verify model loading with different dtypes (fp16, bf16, fp32)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced memory-efficient model loading utility to support optional dtype parameter, providing more flexible data type configuration during model initialization.

* **Tests**
  * Updated test cases to validate dtype parameter behavior in memory-efficient model loading operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Red-Hat-AI-Innovation-Team/mini_trainer/pull/99?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->