### PR TITLE
Pass train_dtype into _load_model_memory_efficient

### DIFF
--- a/src/mini_trainer/osft_utils.py
+++ b/src/mini_trainer/osft_utils.py
@@ -913,6 +913,7 @@ def _load_model_memory_efficient(
     model_args: tuple,
     base_kwargs: dict,
     osft_class_kwargs: dict,
+    train_dtype: torch.dtype | None = None,
 ):
     """
     Memory-efficient loading for OSFT models to avoid CUDA/CPU OOM.
@@ -927,8 +928,8 @@ def _load_model_memory_efficient(
         pretrained_model_name_or_path: Model path or name
         model_args: Positional arguments for model loading
         base_kwargs: Base model kwargs (already filtered)
-        init_cfg: OSFT configuration
         osft_class_kwargs: OSFT class-specific parameters
+        train_dtype: Training dtype for model parameters. Falls back to base_kwargs["torch_dtype"] if not provided.
 
     Returns:
         Loaded OSFT model
@@ -952,9 +953,9 @@ def _load_model_memory_efficient(
     # Remove additional OSFT parameters before calling base model's from_pretrained
     final_base_kwargs = _filter_osft_parameters(base_kwargs, OSFT_BASE_MODEL_FILTERED_PARAMS)
 
-    # Force CPU loading via default behavior and match the train_dtype for FSDP2
-    # Need to get train_dtype from base_kwargs or default to float32
-    load_dtype = base_kwargs.get("torch_dtype")
+    # Resolve the dtype to load the model in: prefer the explicit train_dtype,
+    # fall back to whatever torch_dtype was already set in base_kwargs.
+    load_dtype = train_dtype if train_dtype is not None else base_kwargs.get("torch_dtype")
     if load_dtype is None:
         raise ValueError("error: model does not have a `torch_dtype` setting, please report this to the developers")
     final_base_kwargs["torch_dtype"] = load_dtype
@@ -1334,6 +1335,7 @@ def create_osft_model_class(base_cls) -> type[OSFTModel]:
                     model_args,
                     base_kwargs,
                     osft_class_kwargs,
+                    train_dtype=base_kwargs.get("torch_dtype"),
                 )
             else:
                 # standard non-distributed loading

--- a/tests/test_osft.py
+++ b/tests/test_osft.py
@@ -2203,6 +2203,105 @@ class TestLazyInitTokenizerAlignment:
         assert align_mock.call_count == 1
         assert loaded_models and loaded_models[0].aligned is True
 
+    def test_memory_efficient_loading_train_dtype_overrides_torch_dtype(self, monkeypatch):
+        """train_dtype should take precedence over torch_dtype in base_kwargs."""
+        captured_kwargs = {}
+
+        class DummyLoadedModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.config = MagicMock()
+                self.config.vocab_size = 10
+
+            def state_dict(self):
+                return {"weight": torch.zeros(1)}
+
+            def named_buffers(self):
+                return [("buffer", torch.zeros(1))]
+
+        class DummyBase(nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            @classmethod
+            def from_pretrained(cls, *args, **kwargs):
+                captured_kwargs.update(kwargs)
+                return DummyLoadedModel()
+
+        class DummyOSFT(DummyBase):
+            def __init__(self, config, **kwargs):
+                super().__init__()
+                self.config = config
+                self._lazy_init_pending = True
+
+        monkeypatch.setattr(osft_module.dist, "is_available", lambda: True)
+        monkeypatch.setattr(osft_module.dist, "is_initialized", lambda: True)
+        monkeypatch.setattr(osft_module.dist, "get_rank", lambda: 0)
+        monkeypatch.setattr(osft_module.dist, "barrier", lambda: None)
+        monkeypatch.setattr(osft_module.dist, "broadcast_object_list", lambda *_, **__: None)
+        monkeypatch.setattr(osft_module.torch.cuda, "is_available", lambda: False)
+
+        model = _load_model_memory_efficient(
+            actual_osft_cls=DummyOSFT,
+            pretrained_model_name_or_path="dummy",
+            model_args=tuple(),
+            base_kwargs={"torch_dtype": torch.float32},
+            osft_class_kwargs={},
+            train_dtype=torch.bfloat16,
+        )
+
+        assert isinstance(model, DummyOSFT)
+        assert captured_kwargs["torch_dtype"] == torch.bfloat16
+
+    def test_memory_efficient_loading_falls_back_to_torch_dtype(self, monkeypatch):
+        """When train_dtype is None, should fall back to torch_dtype from base_kwargs."""
+        captured_kwargs = {}
+
+        class DummyLoadedModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.config = MagicMock()
+                self.config.vocab_size = 10
+
+            def state_dict(self):
+                return {"weight": torch.zeros(1)}
+
+            def named_buffers(self):
+                return [("buffer", torch.zeros(1))]
+
+        class DummyBase(nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            @classmethod
+            def from_pretrained(cls, *args, **kwargs):
+                captured_kwargs.update(kwargs)
+                return DummyLoadedModel()
+
+        class DummyOSFT(DummyBase):
+            def __init__(self, config, **kwargs):
+                super().__init__()
+                self.config = config
+                self._lazy_init_pending = True
+
+        monkeypatch.setattr(osft_module.dist, "is_available", lambda: True)
+        monkeypatch.setattr(osft_module.dist, "is_initialized", lambda: True)
+        monkeypatch.setattr(osft_module.dist, "get_rank", lambda: 0)
+        monkeypatch.setattr(osft_module.dist, "barrier", lambda: None)
+        monkeypatch.setattr(osft_module.dist, "broadcast_object_list", lambda *_, **__: None)
+        monkeypatch.setattr(osft_module.torch.cuda, "is_available", lambda: False)
+
+        model = _load_model_memory_efficient(
+            actual_osft_cls=DummyOSFT,
+            pretrained_model_name_or_path="dummy",
+            model_args=tuple(),
+            base_kwargs={"torch_dtype": torch.float16},
+            osft_class_kwargs={},
+        )
+
+        assert isinstance(model, DummyOSFT)
+        assert captured_kwargs["torch_dtype"] == torch.float16
+
 
 class TestPostStepParameterProjection:
     """Test post-step parameter re-projection to fix AdamW subspace leak.


### PR DESCRIPTION
## Summary

- Add explicit `train_dtype` parameter to `_load_model_memory_efficient()` instead of extracting it indirectly from `base_kwargs["torch_dtype"]`
- Caller in `from_pretrained` now passes `train_dtype=base_kwargs.get("torch_dtype")` explicitly
- Falls back to `base_kwargs["torch_dtype"]` when `train_dtype` is not provided (backward compatible)

Closes #34

## Test plan

- [x] New test: `train_dtype` overrides `torch_dtype` in `base_kwargs`
- [x] New test: falls back to `torch_dtype` when `train_dtype` is `None`
- [x] Ruff lint and format checks pass
- [ ] CI should run the full non-GPU test suite to confirm no regressions

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>