### PR TITLE
Pass train_dtype into _load_model_memory_efficient

### DIFF
--- a/src/mini_trainer/osft_utils.py
+++ b/src/mini_trainer/osft_utils.py
@@ -913,6 +913,7 @@ def _load_model_memory_efficient(
     model_args: tuple,
     base_kwargs: dict,
     osft_class_kwargs: dict,
+    train_dtype: torch.dtype,
 ):
     """
     Memory-efficient loading for OSFT models to avoid CUDA/CPU OOM.
@@ -927,8 +928,8 @@ def _load_model_memory_efficient(
         pretrained_model_name_or_path: Model path or name
         model_args: Positional arguments for model loading
         base_kwargs: Base model kwargs (already filtered)
-        init_cfg: OSFT configuration
         osft_class_kwargs: OSFT class-specific parameters
+        train_dtype: Training dtype for model parameters
 
     Returns:
         Loaded OSFT model
@@ -952,12 +953,7 @@ def _load_model_memory_efficient(
     # Remove additional OSFT parameters before calling base model's from_pretrained
     final_base_kwargs = _filter_osft_parameters(base_kwargs, OSFT_BASE_MODEL_FILTERED_PARAMS)
 
-    # Force CPU loading via default behavior and match the train_dtype for FSDP2
-    # Need to get train_dtype from base_kwargs or default to float32
-    load_dtype = base_kwargs.get("torch_dtype")
-    if load_dtype is None:
-        raise ValueError("error: model does not have a `torch_dtype` setting, please report this to the developers")
-    final_base_kwargs["torch_dtype"] = load_dtype
+    final_base_kwargs["torch_dtype"] = train_dtype
 
     # initialize params to instance the OSFT model
     # global rank 0 process actually loads the model, and all other procs
@@ -974,7 +970,7 @@ def _load_model_memory_efficient(
 
     if dist.get_rank() == 0:
         with torch.no_grad():
-            log_rank_0(f"📥 Loading base model to CPU in {load_dtype}...")
+            log_rank_0(f"📥 Loading base model to CPU in {train_dtype}...")
 
             # Check if this is a VLM wrapping a CausalLM text backbone
             _is_vlm = False
@@ -1328,12 +1324,16 @@ def create_osft_model_class(base_cls) -> type[OSFTModel]:
             if fsdp2_lazy_init:
                 # memory-efficient distributed loading
                 log_rank_0("🧠 distributed environment detected, using memory-efficient loading strategy")
+                train_dtype = base_kwargs.get("torch_dtype")
+                if train_dtype is None:
+                    raise ValueError("torch_dtype must be provided in kwargs for memory-efficient loading")
                 model = _load_model_memory_efficient(
                     actual_osft_cls,
                     pretrained_model_name_or_path,
                     model_args,
                     base_kwargs,
                     osft_class_kwargs,
+                    train_dtype=train_dtype,
                 )
             else:
                 # standard non-distributed loading

--- a/tests/test_osft.py
+++ b/tests/test_osft.py
@@ -2197,6 +2197,7 @@ class TestLazyInitTokenizerAlignment:
             model_args=tuple(),
             base_kwargs={"torch_dtype": torch.float32},
             osft_class_kwargs={"lazy_init_tokenizer_align_fn": align_mock},
+            train_dtype=torch.float32,
         )
 
         assert isinstance(model, DummyOSFT)


### PR DESCRIPTION
## Summary

- Adds `train_dtype` as an explicit parameter to `_load_model_memory_efficient` instead of extracting it from `base_kwargs` internally
- Removes the now-unnecessary `torch_dtype` lookup and validation from inside the function
- Updates the call site in `from_pretrained` to extract and validate `torch_dtype` before passing it as `train_dtype`
- Updates the test to pass the new `train_dtype` parameter

Closes #34

## Test plan

- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [ ] `pytest tests/test_osft.py::TestLazyInitTokenizerAlignment` passes (requires torch)
- [ ] CI PR tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>