### PR TITLE
Pass train_dtype explicitly into _load_model_memory_efficient

### DIFF
--- a/src/mini_trainer/osft_utils.py
+++ b/src/mini_trainer/osft_utils.py
@@ -1325,13 +1325,20 @@ def create_osft_model_class(base_cls) -> type[OSFTModel]:
             if fsdp2_lazy_init:
                 # memory-efficient distributed loading
                 log_rank_0("🧠 distributed environment detected, using memory-efficient loading strategy")
+                resolved_train_dtype = base_kwargs.get("torch_dtype", torch.float32)
+                if "torch_dtype" not in base_kwargs:
+                    log_rank_0(
+                        "⚠️ torch_dtype not set — defaulting to float32 for memory-efficient loading. "
+                        "This may use more memory than necessary in distributed training; "
+                        "consider setting torch_dtype to bfloat16."
+                    )
                 model = _load_model_memory_efficient(
                     actual_osft_cls,
                     pretrained_model_name_or_path,
                     model_args,
                     base_kwargs,
                     osft_class_kwargs,
-                    train_dtype=base_kwargs.get("torch_dtype", torch.float32),
+                    train_dtype=resolved_train_dtype,
                 )
             else:
                 # standard non-distributed loading

--- a/src/mini_trainer/osft_utils.py
+++ b/src/mini_trainer/osft_utils.py
@@ -954,6 +954,12 @@ def _load_model_memory_efficient(
     final_base_kwargs = _filter_osft_parameters(base_kwargs, OSFT_BASE_MODEL_FILTERED_PARAMS)
 
     # Force CPU loading in the training dtype for FSDP2
+    if train_dtype == torch.float32 and "torch_dtype" not in base_kwargs:
+        log_rank_0(
+            "⚠️ torch_dtype not set — defaulting to float32 for memory-efficient loading. "
+            "This may use more memory than necessary in distributed training; "
+            "consider setting torch_dtype to bfloat16."
+        )
     final_base_kwargs["torch_dtype"] = train_dtype
 
     # initialize params to instance the OSFT model
@@ -1325,20 +1331,13 @@ def create_osft_model_class(base_cls) -> type[OSFTModel]:
             if fsdp2_lazy_init:
                 # memory-efficient distributed loading
                 log_rank_0("🧠 distributed environment detected, using memory-efficient loading strategy")
-                resolved_train_dtype = base_kwargs.get("torch_dtype", torch.float32)
-                if "torch_dtype" not in base_kwargs:
-                    log_rank_0(
-                        "⚠️ torch_dtype not set — defaulting to float32 for memory-efficient loading. "
-                        "This may use more memory than necessary in distributed training; "
-                        "consider setting torch_dtype to bfloat16."
-                    )
                 model = _load_model_memory_efficient(
                     actual_osft_cls,
                     pretrained_model_name_or_path,
                     model_args,
                     base_kwargs,
                     osft_class_kwargs,
-                    train_dtype=resolved_train_dtype,
+                    train_dtype=base_kwargs.get("torch_dtype", torch.float32),
                 )
             else:
                 # standard non-distributed loading

--- a/src/mini_trainer/osft_utils.py
+++ b/src/mini_trainer/osft_utils.py
@@ -913,6 +913,7 @@ def _load_model_memory_efficient(
     model_args: tuple,
     base_kwargs: dict,
     osft_class_kwargs: dict,
+    train_dtype: torch.dtype = torch.float32,
 ):
     """
     Memory-efficient loading for OSFT models to avoid CUDA/CPU OOM.
@@ -927,8 +928,8 @@ def _load_model_memory_efficient(
         pretrained_model_name_or_path: Model path or name
         model_args: Positional arguments for model loading
         base_kwargs: Base model kwargs (already filtered)
-        init_cfg: OSFT configuration
         osft_class_kwargs: OSFT class-specific parameters
+        train_dtype: Training dtype for model parameters
 
     Returns:
         Loaded OSFT model
@@ -952,12 +953,8 @@ def _load_model_memory_efficient(
     # Remove additional OSFT parameters before calling base model's from_pretrained
     final_base_kwargs = _filter_osft_parameters(base_kwargs, OSFT_BASE_MODEL_FILTERED_PARAMS)
 
-    # Force CPU loading via default behavior and match the train_dtype for FSDP2
-    # Need to get train_dtype from base_kwargs or default to float32
-    load_dtype = base_kwargs.get("torch_dtype")
-    if load_dtype is None:
-        raise ValueError("error: model does not have a `torch_dtype` setting, please report this to the developers")
-    final_base_kwargs["torch_dtype"] = load_dtype
+    # Force CPU loading in the training dtype for FSDP2
+    final_base_kwargs["torch_dtype"] = train_dtype
 
     # initialize params to instance the OSFT model
     # global rank 0 process actually loads the model, and all other procs
@@ -974,7 +971,7 @@ def _load_model_memory_efficient(
 
     if dist.get_rank() == 0:
         with torch.no_grad():
-            log_rank_0(f"📥 Loading base model to CPU in {load_dtype}...")
+            log_rank_0(f"📥 Loading base model to CPU in {train_dtype}...")
 
             # Check if this is a VLM wrapping a CausalLM text backbone
             _is_vlm = False
@@ -1334,6 +1331,7 @@ def create_osft_model_class(base_cls) -> type[OSFTModel]:
                     model_args,
                     base_kwargs,
                     osft_class_kwargs,
+                    train_dtype=base_kwargs.get("torch_dtype", torch.float32),
                 )
             else:
                 # standard non-distributed loading

--- a/tests/test_osft.py
+++ b/tests/test_osft.py
@@ -2204,6 +2204,52 @@ class TestLazyInitTokenizerAlignment:
         assert align_mock.call_count == 1
         assert loaded_models and loaded_models[0].aligned is True
 
+    def test_memory_efficient_loading_warns_on_missing_torch_dtype(self, monkeypatch, capsys):
+        """Warning should be logged when base_kwargs has no torch_dtype."""
+
+        class DummyLoadedModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.config = MagicMock()
+                self.config.vocab_size = 10
+
+            def state_dict(self):
+                return {"weight": torch.zeros(1)}
+
+            def named_buffers(self):
+                return [("buffer", torch.zeros(1))]
+
+        class DummyBase(nn.Module):
+            @classmethod
+            def from_pretrained(cls, *args, **kwargs):
+                return DummyLoadedModel()
+
+        class DummyOSFT(DummyBase):
+            def __init__(self, config, **kwargs):
+                super().__init__()
+                self.config = config
+                self._lazy_init_pending = True
+
+        monkeypatch.setattr(osft_module.dist, "is_available", lambda: True)
+        monkeypatch.setattr(osft_module.dist, "is_initialized", lambda: True)
+        monkeypatch.setattr(osft_module.dist, "get_rank", lambda: 0)
+        monkeypatch.setattr(osft_module.dist, "barrier", lambda: None)
+        monkeypatch.setattr(osft_module.dist, "broadcast_object_list", lambda *_, **__: None)
+        monkeypatch.setattr(osft_module.torch.cuda, "is_available", lambda: False)
+
+        model = _load_model_memory_efficient(
+            actual_osft_cls=DummyOSFT,
+            pretrained_model_name_or_path="dummy",
+            model_args=tuple(),
+            base_kwargs={},
+            osft_class_kwargs={},
+            train_dtype=torch.float32,
+        )
+
+        assert isinstance(model, DummyOSFT)
+        captured = capsys.readouterr()
+        assert "torch_dtype not set" in captured.out
+
 
 class TestPostStepParameterProjection:
     """Test post-step parameter re-projection to fix AdamW subspace leak.

--- a/tests/test_osft.py
+++ b/tests/test_osft.py
@@ -2197,6 +2197,7 @@ class TestLazyInitTokenizerAlignment:
             model_args=tuple(),
             base_kwargs={"torch_dtype": torch.float32},
             osft_class_kwargs={"lazy_init_tokenizer_align_fn": align_mock},
+            train_dtype=torch.float32,
         )
 
         assert isinstance(model, DummyOSFT)


### PR DESCRIPTION
## Summary

- Adds `train_dtype` as an explicit parameter to `_load_model_memory_efficient` instead of extracting it indirectly from `base_kwargs["torch_dtype"]`
- The caller in `from_pretrained` now passes `train_dtype` explicitly from `base_kwargs.get("torch_dtype", torch.float32)`
- Updated test to pass the new parameter

Closes #34

## Test plan

- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [ ] Non-GPU unit tests (`tox -e py312-nogpu`) — requires A100 node
- [ ] GPU tests with model validation — requires A100 node

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved memory-efficient model loading to accept an explicitly configured training data type and apply it consistently during lazy initialization.
  * Rank-0 load logging now reports the configured training data type.
  * Added a warning when the model loading options omit the expected data type.

* **Tests**
  * Updated memory-efficient/lazy-initialization tests to pass and verify the training data type during loader calls.
  * Added coverage to confirm the new warning behavior when the data type is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->