### PR TITLE
Remove osft_output_dtype parameter

### DIFF
--- a/src/mini_trainer/api_train.py
+++ b/src/mini_trainer/api_train.py
@@ -179,8 +179,6 @@ def run_training(torch_args: TorchrunArgs, train_args: TrainingArgs) -> None:
             command.append(f"--osft-target-patterns={','.join(train_args.osft_target_patterns)}")
         if train_args.osft_upcast_dtype:
             command.append(f"--osft-upcast-dtype={train_args.osft_upcast_dtype}")
-        if train_args.osft_output_dtype:
-            command.append(f"--osft-output-dtype={train_args.osft_output_dtype}")
     if train_args.checkpoint_at_epoch:
         command.append("--checkpoint-at-epoch")
 

--- a/src/mini_trainer/osft_utils.py
+++ b/src/mini_trainer/osft_utils.py
@@ -1082,18 +1082,17 @@ def _build_osft_kwargs(osft_rank_ratio, osft_target_patterns):
     return osft_kwargs
 
 
-def _set_osft_dtypes(model, osft_upcast_dtype, osft_output_dtype):
+def _set_osft_dtypes(model, osft_upcast_dtype, train_dtype):
     """
     Set OSFT dtype attributes on model for computation precision control.
 
     Args:
         model: The OSFT model to configure
         osft_upcast_dtype: Upcast dtype for computations
-        osft_output_dtype: Output dtype for results
+        train_dtype: Training dtype, used as the output dtype for OSFT results
     """
     model.upcast_dtype = osft_upcast_dtype
-    if osft_output_dtype:
-        model.output_dtype = osft_output_dtype
+    model.output_dtype = train_dtype
 
 
 def create_osft_model_class(base_cls) -> type[OSFTModel]:

--- a/src/mini_trainer/setup_model_for_training.py
+++ b/src/mini_trainer/setup_model_for_training.py
@@ -778,7 +778,6 @@ def setup_osft_model_distributed(
     osft_rank_ratio=None,
     osft_target_patterns=None,
     osft_upcast_dtype=torch.float32,
-    osft_output_dtype=None,
 ):
     """
     Initialize an OSFT model for distributed training with memory-efficient loading.
@@ -798,7 +797,6 @@ def setup_osft_model_distributed(
         osft_rank_ratio: Ratio for OSFT rank selection
         osft_target_patterns: Patterns for selecting OSFT target parameters
         osft_upcast_dtype: Dtype for OSFT computations
-        osft_output_dtype: Dtype for OSFT outputs
 
     Returns:
         OSFT model ready for FSDP2 wrapping
@@ -977,7 +975,6 @@ def setup_model(
     save_dtype: str | torch.dtype | None = None,
     train_dtype: torch.dtype = torch.float32,
     osft_upcast_dtype: torch.dtype = torch.float32,
-    osft_output_dtype: torch.dtype | None = None,
     osft_rank_ratio: float | None = None,
     osft_target_patterns: list[str] | None = None,
     use_liger_kernels: bool = False,
@@ -1145,8 +1142,6 @@ def setup_model(
     def load_osft_model():
         """Load a model with OSFT (Orthogonal Subspace Fine-Tuning) support."""
         log_rank_0("loading OSFT model")
-        # If osft_output_dtype is not specified, use train_dtype for consistency
-        effective_osft_output_dtype = osft_output_dtype if osft_output_dtype is not None else train_dtype
 
         # We monkey-patch the HF model class OSFT will wrap ahead of time so that liger can be properly loaded.
         # This is necessary because OSFT has to set up the model in a very specfic way which is incompatible with the
@@ -1185,7 +1180,6 @@ def setup_model(
                 osft_rank_ratio=osft_rank_ratio,
                 osft_target_patterns=osft_target_patterns,
                 osft_upcast_dtype=osft_upcast_dtype,
-                osft_output_dtype=effective_osft_output_dtype,
             )
         else:
             # non-distributed path: direct OSFT model creation
@@ -1210,7 +1204,7 @@ def setup_model(
 
         # final configuration
         model = align_model_and_tokenizer(model, tokenizer)
-        _set_osft_dtypes(model, osft_upcast_dtype, effective_osft_output_dtype)
+        _set_osft_dtypes(model, osft_upcast_dtype, train_dtype)
 
         log_rank_0("OSFT model loaded successfully")
         return model

--- a/src/mini_trainer/train.py
+++ b/src/mini_trainer/train.py
@@ -1217,12 +1217,6 @@ def main(
         str | None,
         Option(help="Upcast dtype for OSFT computations. Can be 'float16', 'bfloat16', 'float32', etc."),
     ] = "float32",
-    osft_output_dtype: Annotated[
-        str | None,
-        Option(
-            help="Output dtype for OSFT. If None, uses original model dtype. Can be 'float16', 'bfloat16', 'float32', etc."
-        ),
-    ] = None,
     output_dir: Annotated[str, Option(help="Directory to save checkpoints and logs (required)")] = ...,
     min_samples_per_checkpoint: Annotated[
         int | None,
@@ -1335,7 +1329,6 @@ def main(
 
     # Convert string dtypes to torch dtypes
     osft_upcast_dtype_torch = parse_dtype(osft_upcast_dtype)
-    osft_output_dtype_torch = parse_dtype(osft_output_dtype)
     train_dtype_torch = parse_dtype(train_dtype)
 
     # Initialize logging flags
@@ -1362,7 +1355,6 @@ def main(
             "osft_unfreeze_rank_ratio": osft_unfreeze_rank_ratio,
             "osft_target_patterns": osft_target_patterns,
             "osft_upcast_dtype": osft_upcast_dtype,
-            "osft_output_dtype": osft_output_dtype,
             "trust_remote_code": trust_remote_code,
             "output_dir": output_dir,
             "min_samples_per_checkpoint": min_samples_per_checkpoint,
@@ -1446,7 +1438,6 @@ def main(
         osft_rank_ratio=osft_rank_ratio,
         osft_target_patterns=osft_target_patterns,
         osft_upcast_dtype=osft_upcast_dtype_torch,
-        osft_output_dtype=osft_output_dtype_torch,
         trust_remote_code=trust_remote_code,
     )
 

--- a/src/mini_trainer/training_types.py
+++ b/src/mini_trainer/training_types.py
@@ -120,12 +120,6 @@ class TrainingArgs:
         default="float32",
         metadata={"help": "Upcast dtype for OSFT computations. Can be 'float16', 'bfloat16', 'float32', etc."},
     )
-    osft_output_dtype: str | None = field(
-        default=None,
-        metadata={
-            "help": "Output dtype for OSFT. If None, uses original model dtype. Can be 'float16', 'bfloat16', 'float32', etc."
-        },
-    )
     # Output options
     min_samples_per_checkpoint: int | None = field(
         default=None,

--- a/tests/test_dtype_conversion.py
+++ b/tests/test_dtype_conversion.py
@@ -101,7 +101,7 @@ class TestMainFunctionDtypeIntegration:
                     max_tokens_per_gpu=100,
                     learning_rate=1e-5,
                     output_dir=tmpdir,
-                    # Using defaults: osft_upcast_dtype="float32", osft_output_dtype=None
+                    # Using defaults: osft_upcast_dtype="float32"
                 )
             except SystemExit:
                 pass  # typer might call sys.exit, which is fine for this test
@@ -112,7 +112,6 @@ class TestMainFunctionDtypeIntegration:
 
             # Check that the torch dtypes were passed correctly
             assert call_kwargs["osft_upcast_dtype"] == torch.float32
-            assert call_kwargs["osft_output_dtype"] is None
 
     @patch("torch.distributed.get_world_size", return_value=1)
     @patch("mini_trainer.train.get_node_rank", return_value=0)
@@ -157,7 +156,6 @@ class TestMainFunctionDtypeIntegration:
                     learning_rate=1e-5,
                     output_dir=tmpdir,
                     osft_upcast_dtype="bfloat16",
-                    osft_output_dtype="float16",
                 )
             except SystemExit:
                 pass
@@ -167,7 +165,6 @@ class TestMainFunctionDtypeIntegration:
             call_kwargs = mock_setup_model.call_args.kwargs
 
             assert call_kwargs["osft_upcast_dtype"] == torch.bfloat16
-            assert call_kwargs["osft_output_dtype"] == torch.float16
 
     @patch("torch.distributed.get_world_size", return_value=1)
     @patch("mini_trainer.train.get_node_rank", return_value=0)
@@ -212,7 +209,6 @@ class TestMainFunctionDtypeIntegration:
                     learning_rate=1e-5,
                     output_dir=tmpdir,
                     osft_upcast_dtype=None,
-                    osft_output_dtype=None,
                 )
             except SystemExit:
                 pass
@@ -222,7 +218,6 @@ class TestMainFunctionDtypeIntegration:
             call_kwargs = mock_setup_model.call_args.kwargs
 
             assert call_kwargs["osft_upcast_dtype"] is None
-            assert call_kwargs["osft_output_dtype"] is None
 
     @patch("torch.distributed.get_world_size", return_value=1)
     @patch("mini_trainer.train.get_node_rank", return_value=0)
@@ -293,7 +288,6 @@ class TestDtypeParameterLogging:
                     learning_rate=1e-5,
                     output_dir=tmpdir,
                     osft_upcast_dtype="bfloat16",
-                    osft_output_dtype="float16",
                 )
             except SystemExit:
                 pass
@@ -309,6 +303,5 @@ class TestDtypeParameterLogging:
 
             # Verify dtype parameters are in the logged parameters
             assert "osft_upcast_dtype" in logged_params
-            assert "osft_output_dtype" in logged_params
             assert logged_params["osft_upcast_dtype"] == "bfloat16"
-            assert logged_params["osft_output_dtype"] == "float16"
+            assert "osft_output_dtype" not in logged_params

--- a/tests/test_osft_dtype_functionality.py
+++ b/tests/test_osft_dtype_functionality.py
@@ -300,14 +300,13 @@ class TestOSFTModelDtypeIntegration:
             osft=True,
             local_rank=0,
             osft_upcast_dtype=torch.float32,
-            osft_output_dtype=torch.bfloat16,
             osft_rank_ratio=0.5,
         )
 
         # Verify the attributes were set correctly on the returned model
         assert result is mock_osft_model
         assert result.upcast_dtype == torch.float32
-        assert result.output_dtype == torch.bfloat16
+        assert result.output_dtype == torch.float32
 
         # Verify the OSFT model was created from the base model class
         mock_create_osft.assert_called_once_with(MockBaseModelClass)
@@ -369,7 +368,6 @@ class TestOSFTParameterFlow:
                     osft=True,
                     osft_unfreeze_rank_ratio=0.5,
                     osft_upcast_dtype="bfloat16",
-                    osft_output_dtype="float16",
                 )
             except SystemExit:
                 pass
@@ -379,7 +377,6 @@ class TestOSFTParameterFlow:
             call_kwargs = mock_setup_model.call_args.kwargs
 
             assert call_kwargs["osft_upcast_dtype"] == torch.bfloat16
-            assert call_kwargs["osft_output_dtype"] == torch.float16
 
 
 class TestOSFTDtypeEdgeCases:


### PR DESCRIPTION
## Summary

Closes #36

- Removes the `osft_output_dtype` parameter from the CLI (`--osft-output-dtype`), programmatic API (`TrainingArgs`), and all internal plumbing (`setup_model`, `setup_osft_model_distributed`, `_set_osft_dtypes`)
- OSFT now uses `train_dtype` directly as the output dtype for SVD results, which was already the fallback behavior when `osft_output_dtype` was `None`
- Users can continue to control precision via `osft_upcast_dtype` (computation precision), `train_dtype` (training precision), and `save_dtype` (checkpoint precision)

## Files changed

- `src/mini_trainer/train.py` — removed CLI parameter and its parsing/logging
- `src/mini_trainer/training_types.py` — removed `osft_output_dtype` field from `TrainingArgs`
- `src/mini_trainer/api_train.py` — removed command-line flag generation
- `src/mini_trainer/setup_model_for_training.py` — removed from function signatures, replaced `effective_osft_output_dtype` with `train_dtype`
- `src/mini_trainer/osft_utils.py` — updated `_set_osft_dtypes` to take `train_dtype` and always set `model.output_dtype`
- `tests/test_dtype_conversion.py` — updated assertions to reflect removal
- `tests/test_osft_dtype_functionality.py` — updated assertions to reflect removal

## Test plan

- [x] `ruff check` passes on all changed files
- [x] `ruff format --check` passes on all changed files
- [ ] Non-GPU tests pass (`tox -e py312-nogpu`)
- [ ] GPU validation with `scripts/model_validation.py --run-all --mode osft --simple`

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified OSFT dtype configuration by removing the separate output dtype parameter. Output dtype now automatically follows the training dtype, while the upcast dtype remains independently configurable (defaults to `float32`).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->