### PR TITLE
feat: add class-based callback system for training lifecycle hooks

### DIFF
--- a/src/mini_trainer/__init__.py
+++ b/src/mini_trainer/__init__.py
@@ -16,6 +16,7 @@ from . import (
     api_train,
     batch_metrics,
     batch_packer,
+    callbacks,
     none_reduction_losses,
     osft_utils,
     sampler,
@@ -26,12 +27,14 @@ from . import (
 
 # Export main API functions for convenience
 from .api_train import run_training
+from .callbacks import CallbackManager, TrainerCallback, TrainingContext
 from .training_types import PretrainingConfig, TorchrunArgs, TrainingArgs, TrainingMode
 
 __all__ = [
     "api_train",
     "batch_metrics",
     "batch_packer",
+    "callbacks",
     "none_reduction_losses",
     "sampler",
     "setup_model_for_training",
@@ -44,4 +47,7 @@ __all__ = [
     "TrainingArgs",
     "TrainingMode",
     "PretrainingConfig",
+    "CallbackManager",
+    "TrainerCallback",
+    "TrainingContext",
 ]

--- a/src/mini_trainer/api_train.py
+++ b/src/mini_trainer/api_train.py
@@ -197,6 +197,11 @@ def run_training(torch_args: TorchrunArgs, train_args: TrainingArgs) -> None:
     if train_args.resume_from_full_state_checkpoint:
         command.append(f"--resume-from-full-state-checkpoint={train_args.resume_from_full_state_checkpoint}")
 
+    if train_args.callbacks:
+        from mini_trainer.callbacks import serialize_callbacks_for_cli
+
+        command.append(f"--serialized-callbacks={serialize_callbacks_for_cli(train_args.callbacks)}")
+
     logger.info("Running training command as subprocess: %s", " ".join(command))
 
     # Install parent-side signal handler for on-demand checkpointing.

--- a/src/mini_trainer/callbacks.py
+++ b/src/mini_trainer/callbacks.py
@@ -58,6 +58,8 @@ class TrainingContext:
     max_steps: int = 0
     max_tokens: int = 0
     world_size: int = 1
+    is_local_process_zero: bool = True
+    is_world_process_zero: bool = True
 
 
 class TrainerCallback:
@@ -91,16 +93,16 @@ class CallbackManager:
 
     Callbacks are dispatched asynchronously on a background event loop.
     Exceptions are caught and logged, never propagated to the training loop.
-    Callbacks only fire on rank-0 processes.
+    Callbacks fire on all ranks. Use context.is_world_process_zero or
+    context.is_local_process_zero inside your callback to gate behavior.
 
     The manager holds a shared TrainingContext that the training loop updates
     in place. On each fire(), a shallow copy is snapshotted and dispatched
     to callbacks so they see a consistent, effectively frozen view.
     """
 
-    def __init__(self, is_rank_0: bool = True):
+    def __init__(self):
         self._callbacks: list[TrainerCallback] = []
-        self._is_rank_0 = is_rank_0
         self.context = TrainingContext()
 
         self._loop = asyncio.new_event_loop()
@@ -126,8 +128,6 @@ class CallbackManager:
             self._callbacks = [cb for cb in self._callbacks if cb is not callback_or_type]
 
     def fire(self, hook_name: str, **kwargs) -> None:
-        if not self._is_rank_0:
-            return
         if not self.has_callbacks(hook_name):
             return
 

--- a/src/mini_trainer/callbacks.py
+++ b/src/mini_trainer/callbacks.py
@@ -67,6 +67,11 @@ class TrainerCallback:
 
     All methods are no-ops by default. Callbacks receive a TrainingContext
     snapshot and are purely observational (they cannot affect training flow).
+    Callbacks fire on all ranks; use context.is_world_process_zero or
+    context.is_local_process_zero to gate rank-specific behavior.
+
+    Note: on_before_forward and on_after_backward fire once per microbatch
+    inside the gradient accumulation loop, not once per training step.
 
     Callbacks must be self-contained for serialization across the torchrun
     subprocess boundary: all imports must be inside method bodies, and
@@ -133,6 +138,8 @@ class CallbackManager:
 
         snapshot = copy.copy(self.context)
         snapshot.hook_name = hook_name
+        snapshot.batch_metrics = dict(snapshot.batch_metrics)
+        snapshot.val_metrics = dict(snapshot.val_metrics)
         for key, value in kwargs.items():
             setattr(snapshot, key, value)
 

--- a/src/mini_trainer/callbacks.py
+++ b/src/mini_trainer/callbacks.py
@@ -1,0 +1,210 @@
+import asyncio
+import base64
+import copy
+import inspect
+import json
+import logging
+import textwrap
+import threading
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+HOOK_NAMES = [
+    "on_train_begin",
+    "on_epoch_begin",
+    "on_step_begin",
+    "on_before_forward",
+    "on_after_backward",
+    "on_pre_optimizer_step",
+    "on_optimizer_step",
+    "on_log",
+    "on_evaluate",
+    "on_save",
+    "on_step_end",
+    "on_epoch_end",
+    "on_train_end",
+]
+
+
+@dataclass
+class TrainingContext:
+    """Mutable training state maintained by the training loop.
+
+    The CallbackManager snapshots this before dispatching to callbacks,
+    so callback authors receive an effectively read-only view.
+    """
+
+    hook_name: str = ""
+
+    step: int = 0
+    epoch: int = 0
+    total_samples: int = 0
+    total_tokens: int = 0
+
+    loss: float | None = None
+    learning_rate: float | None = None
+    grad_norm: float | None = None
+
+    batch_metrics: dict[str, Any] = field(default_factory=dict)
+    val_metrics: dict[str, Any] = field(default_factory=dict)
+    checkpoint_path: str | None = None
+
+    output_dir: str = ""
+    model_name_or_path: str = ""
+    training_mode: str = ""
+    max_epochs: int = 0
+    max_steps: int = 0
+    max_tokens: int = 0
+    world_size: int = 1
+
+
+class TrainerCallback:
+    """Base class for training callbacks. Subclass and override the hooks you need.
+
+    All methods are no-ops by default. Callbacks receive a TrainingContext
+    snapshot and are purely observational (they cannot affect training flow).
+
+    Callbacks must be self-contained for serialization across the torchrun
+    subprocess boundary: all imports must be inside method bodies, and
+    constructors must work with no arguments (or all-default arguments).
+    """
+
+    def on_train_begin(self, context: TrainingContext) -> None: pass
+    def on_epoch_begin(self, context: TrainingContext) -> None: pass
+    def on_step_begin(self, context: TrainingContext) -> None: pass
+    def on_before_forward(self, context: TrainingContext) -> None: pass
+    def on_after_backward(self, context: TrainingContext) -> None: pass
+    def on_pre_optimizer_step(self, context: TrainingContext) -> None: pass
+    def on_optimizer_step(self, context: TrainingContext) -> None: pass
+    def on_log(self, context: TrainingContext) -> None: pass
+    def on_evaluate(self, context: TrainingContext) -> None: pass
+    def on_save(self, context: TrainingContext) -> None: pass
+    def on_step_end(self, context: TrainingContext) -> None: pass
+    def on_epoch_end(self, context: TrainingContext) -> None: pass
+    def on_train_end(self, context: TrainingContext) -> None: pass
+
+
+class CallbackManager:
+    """Manages training callbacks with async fire-and-forget dispatch.
+
+    Callbacks are dispatched asynchronously on a background event loop.
+    Exceptions are caught and logged, never propagated to the training loop.
+    Callbacks only fire on rank-0 processes.
+
+    The manager holds a shared TrainingContext that the training loop updates
+    in place. On each fire(), a shallow copy is snapshotted and dispatched
+    to callbacks so they see a consistent, effectively frozen view.
+    """
+
+    def __init__(self, is_rank_0: bool = True):
+        self._callbacks: list[TrainerCallback] = []
+        self._is_rank_0 = is_rank_0
+        self.context = TrainingContext()
+
+        self._loop = asyncio.new_event_loop()
+        self._thread = threading.Thread(target=self._run_event_loop, daemon=True)
+        self._thread.start()
+
+    def _run_event_loop(self):
+        asyncio.set_event_loop(self._loop)
+        self._loop.run_forever()
+
+    def add_callback(self, callback: TrainerCallback) -> None:
+        if not isinstance(callback, TrainerCallback):
+            raise TypeError(
+                f"Expected a TrainerCallback instance, got {type(callback).__name__}. "
+                f"Pass an instance, not a class: callbacks=[MyCallback()]"
+            )
+        self._callbacks.append(callback)
+
+    def remove_callback(self, callback_or_type) -> None:
+        if isinstance(callback_or_type, type):
+            self._callbacks = [cb for cb in self._callbacks if not isinstance(cb, callback_or_type)]
+        else:
+            self._callbacks = [cb for cb in self._callbacks if cb is not callback_or_type]
+
+    def fire(self, hook_name: str, **kwargs) -> None:
+        if not self._is_rank_0:
+            return
+        if not self.has_callbacks(hook_name):
+            return
+
+        snapshot = copy.copy(self.context)
+        snapshot.hook_name = hook_name
+        for key, value in kwargs.items():
+            setattr(snapshot, key, value)
+
+        for callback in self._callbacks:
+            method = getattr(callback, hook_name)
+            if getattr(type(callback), hook_name) is getattr(TrainerCallback, hook_name):
+                continue
+            future = asyncio.run_coroutine_threadsafe(self._safe_invoke(method, snapshot), self._loop)
+            if hook_name == "on_train_end":
+                try:
+                    future.result(timeout=10)
+                except Exception:
+                    pass
+
+    async def _safe_invoke(self, method, context: TrainingContext) -> None:
+        try:
+            result = method(context)
+            if asyncio.iscoroutine(result):
+                await result
+        except Exception:
+            logger.exception(
+                "Callback %s.%s raised an exception (hook=%s, step=%d). "
+                "This exception is suppressed and will not affect training.",
+                type(method.__self__).__name__ if hasattr(method, "__self__") else repr(method),
+                method.__name__,
+                context.hook_name,
+                context.step,
+            )
+
+    def has_callbacks(self, hook_name: str) -> bool:
+        base_method = getattr(TrainerCallback, hook_name)
+        return any(getattr(type(cb), hook_name) is not base_method for cb in self._callbacks)
+
+
+# ---------------------------------------------------------------------------
+# Serialization utilities for crossing the torchrun subprocess boundary
+# ---------------------------------------------------------------------------
+
+
+def serialize_callback(callback: TrainerCallback) -> str:
+    """Serialize a TrainerCallback subclass to a base64 string.
+
+    The class must be self-contained: all imports must be inside method
+    bodies. The constructor must work with no arguments (or all defaults).
+    """
+    source = inspect.getsource(type(callback))
+    source = textwrap.dedent(source)
+    return base64.b64encode(source.encode("utf-8")).decode("ascii")
+
+
+def deserialize_callback(encoded: str) -> TrainerCallback:
+    """Reconstruct a TrainerCallback instance from a base64-encoded class source."""
+    source = base64.b64decode(encoded).decode("utf-8")
+    namespace: dict[str, Any] = {"TrainerCallback": TrainerCallback, "TrainingContext": TrainingContext}
+    # Only called with source from api_train.py serialization, never untrusted input
+    exec(source, namespace)  # noqa: S102
+    classes = [
+        v for v in namespace.values()
+        if isinstance(v, type) and issubclass(v, TrainerCallback) and v is not TrainerCallback
+    ]
+    if len(classes) != 1:
+        raise ValueError(f"Expected exactly one TrainerCallback subclass, got {len(classes)}. Source:\n{source}")
+    return classes[0]()
+
+
+def serialize_callbacks_for_cli(callbacks: list[TrainerCallback]) -> str:
+    """Serialize a list of TrainerCallback instances to a base64 string for CLI transport."""
+    serialized = [serialize_callback(cb) for cb in callbacks]
+    return base64.b64encode(json.dumps(serialized).encode("utf-8")).decode("ascii")
+
+
+def deserialize_callbacks_from_cli(encoded: str) -> list[TrainerCallback]:
+    """Reconstruct TrainerCallback instances from CLI-transported base64 string."""
+    decoded = json.loads(base64.b64decode(encoded).decode("utf-8"))
+    return [deserialize_callback(s) for s in decoded]

--- a/src/mini_trainer/callbacks.py
+++ b/src/mini_trainer/callbacks.py
@@ -118,6 +118,11 @@ class CallbackManager:
         asyncio.set_event_loop(self._loop)
         self._loop.run_forever()
 
+    def close(self):
+        self._loop.call_soon_threadsafe(self._loop.stop)
+        self._thread.join(timeout=5)
+        self._loop.close()
+
     def add_callback(self, callback: TrainerCallback) -> None:
         if not isinstance(callback, TrainerCallback):
             raise TypeError(
@@ -140,7 +145,10 @@ class CallbackManager:
         snapshot.hook_name = hook_name
         snapshot.batch_metrics = dict(snapshot.batch_metrics)
         snapshot.val_metrics = dict(snapshot.val_metrics)
+        _valid_fields = {f.name for f in snapshot.__dataclass_fields__.values()}
         for key, value in kwargs.items():
+            if key not in _valid_fields:
+                raise ValueError(f"Unknown TrainingContext field: '{key}'. Valid fields: {sorted(_valid_fields)}")
             setattr(snapshot, key, value)
 
         for callback in self._callbacks:
@@ -151,6 +159,12 @@ class CallbackManager:
             if hook_name == "on_train_end":
                 try:
                     future.result(timeout=10)
+                except TimeoutError:
+                    logger.warning(
+                        "Callback %s.%s timed out during on_train_end (10s limit).",
+                        type(callback).__name__,
+                        hook_name,
+                    )
                 except Exception:
                     pass
 

--- a/src/mini_trainer/train.py
+++ b/src/mini_trainer/train.py
@@ -1024,7 +1024,7 @@ def train(
             grad_norm = take_gradient_step(model, optimizer, lr_scheduler, expected_dtype=train_dtype)
 
             if callback_manager:
-                callback_manager.context.grad_norm = grad_norm.item()
+                callback_manager.context.grad_norm = grad_norm.item() if grad_norm is not None else None
                 callback_manager.fire("on_optimizer_step")
 
             batch_time = time.time() - batch_start_time
@@ -1067,7 +1067,7 @@ def train(
 
             if callback_manager:
                 callback_manager.context.loss = logged_loss
-                callback_manager.context.batch_metrics = batch_metrics
+                callback_manager.context.batch_metrics = dict(batch_metrics)
                 callback_manager.fire("on_log")
 
             # Log metrics (progress info is printed by the logger)

--- a/src/mini_trainer/train.py
+++ b/src/mini_trainer/train.py
@@ -846,6 +846,8 @@ def train(
         ctx.max_steps = max_steps
         ctx.max_tokens = max_tokens
         ctx.world_size = world_size
+        ctx.is_local_process_zero = is_local_main_process
+        ctx.is_world_process_zero = is_main_process
         ctx.step = step
         ctx.epoch = epoch
         ctx.total_samples = total_samples_accumulated
@@ -1618,8 +1620,7 @@ def main(
     if serialized_callbacks:
         from mini_trainer.callbacks import deserialize_callbacks_from_cli
 
-        _is_rank_0 = int(os.getenv("LOCAL_RANK", 0)) == 0
-        _callback_manager = CallbackManager(is_rank_0=_is_rank_0)
+        _callback_manager = CallbackManager()
         for _cb in deserialize_callbacks_from_cli(serialized_callbacks):
             _callback_manager.add_callback(_cb)
 

--- a/src/mini_trainer/train.py
+++ b/src/mini_trainer/train.py
@@ -17,6 +17,7 @@ from typer import Option, Typer
 from mini_trainer import mlflow_wrapper, wandb_wrapper
 from mini_trainer.async_structured_logger import AsyncStructuredLogger
 from mini_trainer.batch_metrics import BatchMetrics
+from mini_trainer.callbacks import CallbackManager
 from mini_trainer.full_state_checkpoint import FullStateCheckpointer, find_latest_full_state_checkpoint
 from mini_trainer.sampler import get_data_loader
 from mini_trainer.setup_model_for_training import setup_model, setup_training_components
@@ -685,6 +686,7 @@ def train(
     trust_remote_code: bool = False,
     on_demand_checkpointing: bool = False,
     resume_from_full_state_checkpoint: str | None = None,
+    callback_manager: CallbackManager | None = None,
 ):
     """
     Runs the model training loop.
@@ -834,6 +836,22 @@ def train(
     # We skip by step count (not sample count) to stay consistent across ranks.
     _resume_target_step = step if resume_from_full_state_checkpoint else None
 
+    # Initialize callback context with static training parameters
+    if callback_manager:
+        ctx = callback_manager.context
+        ctx.output_dir = output_dir
+        ctx.model_name_or_path = model_name_or_path
+        ctx.training_mode = training_mode.value if isinstance(training_mode, TrainingMode) else str(training_mode)
+        ctx.max_epochs = max_epochs
+        ctx.max_steps = max_steps
+        ctx.max_tokens = max_tokens
+        ctx.world_size = world_size
+        ctx.step = step
+        ctx.epoch = epoch
+        ctx.total_samples = total_samples_accumulated
+        ctx.total_tokens = total_tokens_processed
+        callback_manager.fire("on_train_begin")
+
     # main training loop
     while not reached_stop_condition(
         training_mode=training_mode,
@@ -846,6 +864,10 @@ def train(
     ):
         # set the current epoch
         data_loader.sampler.set_epoch(epoch)
+
+        if callback_manager:
+            callback_manager.fire("on_epoch_begin")
+
         data_loader_it = iter(data_loader)
 
         _skipped_steps = 0
@@ -873,6 +895,11 @@ def train(
             batch_start_time = time.time()
             batch_totals.reset_batch()
             torch.cuda.reset_peak_memory_stats()
+
+            if callback_manager:
+                callback_manager.context.step = step
+                callback_manager.fire("on_step_begin")
+
             _interrupted = False
             for grad_accum, mb in enumerate(batch):
                 # Check for on-demand checkpoint before forward pass
@@ -896,6 +923,9 @@ def train(
                 if (attn_mask := mb.get("attention_mask")) is not None:
                     model_inputs["attention_mask"] = attn_mask.to(device)
 
+                if callback_manager and callback_manager.has_callbacks("on_before_forward"):
+                    callback_manager.fire("on_before_forward")
+
                 output = model(**model_inputs)
 
                 # GPT-OSS: add auxiliary loss if present, otherwise use standard loss
@@ -913,6 +943,11 @@ def train(
                 loss = (loss / batch_num_loss_counted_tokens) * world_size
                 loss_metrics = loss.detach().cpu().item()
                 loss.backward()
+
+                if callback_manager and callback_manager.has_callbacks("on_after_backward"):
+                    callback_manager.context.loss = loss_metrics
+                    callback_manager.fire("on_after_backward")
+
                 torch.cuda.empty_cache()
 
                 batch_totals.accumulate_minibatch_metrics(
@@ -971,9 +1006,24 @@ def train(
             total_samples_accumulated += bm["num_samples"]
             total_tokens_processed += batch_num_loss_counted_tokens  # Track tokens for TOKEN mode
 
+            if callback_manager:
+                ctx = callback_manager.context
+                ctx.step = step
+                ctx.total_samples = total_samples_accumulated
+                ctx.total_tokens = total_tokens_processed
+
             # capture the LR that we'll use when taking a training step
             current_lr = lr_scheduler.get_last_lr()[0]
+
+            if callback_manager:
+                callback_manager.context.learning_rate = current_lr
+                callback_manager.fire("on_pre_optimizer_step")
+
             grad_norm = take_gradient_step(model, optimizer, lr_scheduler, expected_dtype=train_dtype)
+
+            if callback_manager:
+                callback_manager.context.grad_norm = grad_norm.item()
+                callback_manager.fire("on_optimizer_step")
 
             batch_time = time.time() - batch_start_time
 
@@ -1009,6 +1059,14 @@ def train(
                     last_validation_loss = val_metrics["val_loss"]
                     print(f"Validation loss: {last_validation_loss}")
                 batch_metrics.update(val_metrics)
+
+                if callback_manager:
+                    callback_manager.fire("on_evaluate", val_metrics=val_metrics)
+
+            if callback_manager:
+                callback_manager.context.loss = logged_loss
+                callback_manager.context.batch_metrics = batch_metrics
+                callback_manager.fire("on_log")
 
             # Log metrics (progress info is printed by the logger)
             if is_local_main_process:
@@ -1058,6 +1116,10 @@ def train(
                 )
                 checkpointer.record_save("min_samples", total_samples_accumulated)
 
+                if callback_manager:
+                    _ckpt = str(Path(output_dir) / "hf_format" / f"samples_{total_samples_accumulated}")
+                    callback_manager.fire("on_save", checkpoint_path=_ckpt)
+
             # Check for best validation loss saving after validation runs
             if checkpointer.should_save_checkpoint(
                 save_type="best_val_loss",
@@ -1074,7 +1136,14 @@ def train(
                 )
                 checkpointer.record_save("best_val_loss", total_samples_accumulated, last_validation_loss)
 
+                if callback_manager:
+                    _ckpt = str(Path(output_dir) / "hf_format" / f"samples_{total_samples_accumulated}_best_val_loss")
+                    callback_manager.fire("on_save", checkpoint_path=_ckpt)
+
             torch.distributed.barrier()
+
+            if callback_manager:
+                callback_manager.fire("on_step_end")
 
             # Check stopping condition after each step (for STEP and TOKEN modes)
             if reached_stop_condition(
@@ -1090,6 +1159,9 @@ def train(
 
         # Increment epoch counter after completing an epoch
         epoch += 1
+
+        if callback_manager:
+            callback_manager.context.epoch = epoch
 
         # save at the current number of samples seen
         # should save at the end of each epoch
@@ -1107,6 +1179,13 @@ def train(
             )
             checkpointer.record_save("epoch", total_samples_accumulated)
 
+            if callback_manager:
+                _ckpt = str(Path(output_dir) / "hf_format" / f"samples_{total_samples_accumulated}")
+                callback_manager.fire("on_save", checkpoint_path=_ckpt)
+
+        if callback_manager:
+            callback_manager.fire("on_epoch_end")
+
     torch.distributed.barrier()
     # save one last time if we haven't yet
     if checkpointer.should_save_checkpoint(
@@ -1122,6 +1201,13 @@ def train(
             trust_remote_code=trust_remote_code,
         )
         checkpointer.record_save("final", total_samples_accumulated)
+
+        if callback_manager:
+            _ckpt = str(Path(output_dir) / "hf_format" / f"samples_{total_samples_accumulated}")
+            callback_manager.fire("on_save", checkpoint_path=_ckpt)
+
+    if callback_manager:
+        callback_manager.fire("on_train_end")
 
 
 def calculate_num_training_steps(
@@ -1295,6 +1381,11 @@ def main(
     mlflow_tracking_uri: Annotated[str | None, Option(help="MLflow tracking server URI")] = None,
     mlflow_experiment_name: Annotated[str | None, Option(help="MLflow experiment name")] = None,
     mlflow_run_name: Annotated[str | None, Option(help="MLflow run name")] = None,
+    # Callback support (internal: populated by api_train.py)
+    serialized_callbacks: Annotated[
+        str | None,
+        Option(help="Base64-encoded serialized callbacks (internal use by api_train)"),
+    ] = None,
 ):
     # Reproducibility: align with HF Trainer seeding behavior
     set_seed(seed)
@@ -1522,6 +1613,16 @@ def main(
         resume_from_checkpoint=resume_from_full_state_checkpoint,
     )
 
+    # Reconstruct callbacks from serialized CLI arg
+    _callback_manager = None
+    if serialized_callbacks:
+        from mini_trainer.callbacks import deserialize_callbacks_from_cli
+
+        _is_rank_0 = int(os.getenv("LOCAL_RANK", 0)) == 0
+        _callback_manager = CallbackManager(is_rank_0=_is_rank_0)
+        for _cb in deserialize_callbacks_from_cli(serialized_callbacks):
+            _callback_manager.add_callback(_cb)
+
     train(
         model=model,
         optimizer=optimizer,
@@ -1546,6 +1647,7 @@ def main(
         trust_remote_code=trust_remote_code,
         on_demand_checkpointing=on_demand_checkpointing,
         resume_from_full_state_checkpoint=resume_from_full_state_checkpoint,
+        callback_manager=_callback_manager,
     )
 
     # once done, tear down distributed environment

--- a/src/mini_trainer/training_types.py
+++ b/src/mini_trainer/training_types.py
@@ -234,3 +234,13 @@ class TrainingArgs:
             "The checkpoint must have been saved by the on-demand checkpointing system."
         },
     )
+
+    # Callbacks (async, fire-and-forget)
+    callbacks: list | None = field(
+        default=None,
+        metadata={
+            "help": "List of TrainerCallback instances. Subclass TrainerCallback and "
+            "override the hooks you need. Callbacks must be self-contained (all imports "
+            "inside method bodies) to work across the torchrun subprocess boundary."
+        },
+    )

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -1,9 +1,9 @@
 """
 Test suite for the callback system.
 
-Tests async fire-and-forget dispatch, rank-0 gating, mutable context with
-snapshot isolation, class-based interface, and serialization for crossing
-the torchrun subprocess boundary.
+Tests async fire-and-forget dispatch, per-rank context exposure, mutable
+context with snapshot isolation, class-based interface, and serialization
+for crossing the torchrun subprocess boundary.
 """
 
 import asyncio
@@ -14,7 +14,6 @@ import time
 import pytest
 
 from mini_trainer.callbacks import (
-    HOOK_NAMES,
     CallbackManager,
     TrainerCallback,
     TrainingContext,

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -36,6 +36,8 @@ class TestTrainingContext:
         assert ctx.loss is None
         assert ctx.batch_metrics == {}
         assert ctx.world_size == 1
+        assert ctx.is_local_process_zero is True
+        assert ctx.is_world_process_zero is True
 
     def test_mutable_fields(self):
         """Test that TrainingContext fields can be updated in place."""
@@ -169,20 +171,20 @@ class TestCallbackManager:
 
     def test_add_callback(self):
         """Test adding a TrainerCallback instance."""
-        mgr = CallbackManager(is_rank_0=True)
+        mgr = CallbackManager()
         cb = _SignalCallback()
         mgr.add_callback(cb)
         assert mgr.has_callbacks("on_step_end")
 
     def test_add_callback_rejects_non_instance(self):
         """Test that passing a class instead of an instance raises TypeError."""
-        mgr = CallbackManager(is_rank_0=True)
+        mgr = CallbackManager()
         with pytest.raises(TypeError, match="Expected a TrainerCallback instance"):
             mgr.add_callback(_SignalCallback)
 
     def test_remove_callback_by_instance(self):
         """Test removing a specific callback instance."""
-        mgr = CallbackManager(is_rank_0=True)
+        mgr = CallbackManager()
         cb = _SignalCallback()
         mgr.add_callback(cb)
         assert mgr.has_callbacks("on_step_end")
@@ -191,7 +193,7 @@ class TestCallbackManager:
 
     def test_remove_callback_by_type(self):
         """Test removing all callbacks of a given type."""
-        mgr = CallbackManager(is_rank_0=True)
+        mgr = CallbackManager()
         mgr.add_callback(_SignalCallback())
         mgr.add_callback(_SignalCallback())
         assert mgr.has_callbacks("on_step_end")
@@ -201,7 +203,7 @@ class TestCallbackManager:
     def test_fire_invokes_callback(self):
         """Test that fire() dispatches the callback with correct context."""
         cb = _StepRecorderCallback()
-        mgr = CallbackManager(is_rank_0=True)
+        mgr = CallbackManager()
         mgr.context.step = 7
         mgr.add_callback(cb)
         mgr.fire("on_train_begin")
@@ -213,26 +215,37 @@ class TestCallbackManager:
         """Test that fire() invokes all registered callbacks for a hook."""
         cb1 = _SignalCallback()
         cb2 = _SignalCallback()
-        mgr = CallbackManager(is_rank_0=True)
+        mgr = CallbackManager()
         mgr.add_callback(cb1)
         mgr.add_callback(cb2)
         mgr.fire("on_step_end")
         assert cb1.event.wait(timeout=5)
         assert cb2.event.wait(timeout=5)
 
-    def test_fire_rank0_only(self):
-        """Test that callbacks are suppressed on non-rank-0 processes."""
-        cb = _SignalCallback()
-        mgr = CallbackManager(is_rank_0=False)
+    def test_fire_on_all_ranks(self):
+        """Test that callbacks fire regardless of rank; rank info is on context."""
+        cb = _StepRecorderCallback()
+        mgr = CallbackManager()
+        mgr.context.is_world_process_zero = False
+        mgr.context.is_local_process_zero = False
         mgr.add_callback(cb)
-        mgr.fire("on_step_end")
-        time.sleep(0.2)
-        assert not cb.event.is_set(), "Callback should not fire on non-rank-0"
+        mgr.fire("on_train_begin")
+        assert cb.event.wait(timeout=5), "Callback should fire on non-rank-0 processes"
+
+    def test_rank_info_on_context(self):
+        """Test that is_local_process_zero and is_world_process_zero are on context."""
+        mgr = CallbackManager()
+        assert mgr.context.is_local_process_zero is True
+        assert mgr.context.is_world_process_zero is True
+        mgr.context.is_local_process_zero = False
+        mgr.context.is_world_process_zero = False
+        assert mgr.context.is_local_process_zero is False
+        assert mgr.context.is_world_process_zero is False
 
     def test_fire_exception_swallowed(self):
         """Test that callback exceptions do not propagate to the caller."""
         cb = _ExplodingCallback()
-        mgr = CallbackManager(is_rank_0=True)
+        mgr = CallbackManager()
         mgr.add_callback(cb)
         mgr.fire("on_step_end")
         assert cb.event.wait(timeout=5), "Callback should have been invoked"
@@ -252,7 +265,7 @@ class TestCallbackManager:
         cb_logger.addHandler(handler)
         cb_logger.setLevel(logging.ERROR)
         try:
-            mgr = CallbackManager(is_rank_0=True)
+            mgr = CallbackManager()
             mgr.add_callback(cb)
             mgr.fire("on_log")
             cb.event.wait(timeout=5)
@@ -263,7 +276,7 @@ class TestCallbackManager:
 
     def test_has_callbacks_detects_overridden(self):
         """Test has_callbacks() returns True only for overridden hooks."""
-        mgr = CallbackManager(is_rank_0=True)
+        mgr = CallbackManager()
         mgr.add_callback(_SignalCallback())
         assert mgr.has_callbacks("on_step_end")
         assert not mgr.has_callbacks("on_train_begin")
@@ -271,18 +284,18 @@ class TestCallbackManager:
 
     def test_has_callbacks_no_callbacks(self):
         """Test has_callbacks() returns False when no callbacks registered."""
-        mgr = CallbackManager(is_rank_0=True)
+        mgr = CallbackManager()
         assert not mgr.has_callbacks("on_train_begin")
 
     def test_fire_no_callbacks_is_noop(self):
         """Test that fire() with no registered callbacks is a safe no-op."""
-        mgr = CallbackManager(is_rank_0=True)
+        mgr = CallbackManager()
         mgr.fire("on_train_begin")
 
     def test_async_callback_support(self):
         """Test that async (coroutine) callbacks are awaited correctly."""
         cb = _AsyncCallback()
-        mgr = CallbackManager(is_rank_0=True)
+        mgr = CallbackManager()
         mgr.context.step = 99
         mgr.add_callback(cb)
         mgr.fire("on_epoch_end")
@@ -292,7 +305,7 @@ class TestCallbackManager:
     def test_on_train_end_waits_for_completion(self):
         """Test that on_train_end blocks until callbacks finish."""
         cb = _SlowTrainEndCallback()
-        mgr = CallbackManager(is_rank_0=True)
+        mgr = CallbackManager()
         mgr.add_callback(cb)
         mgr.fire("on_train_end")
         assert cb.result.get("done"), "on_train_end should wait for callback to complete"
@@ -300,7 +313,7 @@ class TestCallbackManager:
     def test_fire_kwargs_override_context(self):
         """Test that kwargs passed to fire() override context fields in the snapshot."""
         cb = _SaveRecorderCallback()
-        mgr = CallbackManager(is_rank_0=True)
+        mgr = CallbackManager()
         mgr.context.step = 10
         mgr.context.checkpoint_path = None
         mgr.add_callback(cb)
@@ -313,7 +326,7 @@ class TestCallbackManager:
     def test_snapshot_isolation(self):
         """Test that callbacks receive a snapshot, not a reference to the shared context."""
         cb = _StepEndRecorderCallback()
-        mgr = CallbackManager(is_rank_0=True)
+        mgr = CallbackManager()
         mgr.context.step = 42
         mgr.add_callback(cb)
         mgr.fire("on_step_end")
@@ -324,7 +337,7 @@ class TestCallbackManager:
     def test_multi_hook_callback(self):
         """Test that a single callback can implement multiple hooks."""
         cb = _MultiHookCallback()
-        mgr = CallbackManager(is_rank_0=True)
+        mgr = CallbackManager()
         mgr.add_callback(cb)
         mgr.fire("on_train_begin")
         mgr.fire("on_log")

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -1,0 +1,432 @@
+"""
+Test suite for the callback system.
+
+Tests async fire-and-forget dispatch, rank-0 gating, mutable context with
+snapshot isolation, class-based interface, and serialization for crossing
+the torchrun subprocess boundary.
+"""
+
+import asyncio
+import logging
+import threading
+import time
+
+import pytest
+
+from mini_trainer.callbacks import (
+    HOOK_NAMES,
+    CallbackManager,
+    TrainerCallback,
+    TrainingContext,
+    deserialize_callback,
+    deserialize_callbacks_from_cli,
+    serialize_callback,
+    serialize_callbacks_for_cli,
+)
+
+
+class TestTrainingContext:
+    """Test suite for TrainingContext dataclass."""
+
+    def test_default_values(self):
+        """Test TrainingContext default field values."""
+        ctx = TrainingContext()
+        assert ctx.step == 0
+        assert ctx.epoch == 0
+        assert ctx.loss is None
+        assert ctx.batch_metrics == {}
+        assert ctx.world_size == 1
+
+    def test_mutable_fields(self):
+        """Test that TrainingContext fields can be updated in place."""
+        ctx = TrainingContext()
+        ctx.step = 5
+        ctx.epoch = 2
+        ctx.loss = 0.42
+        assert ctx.step == 5
+        assert ctx.epoch == 2
+        assert ctx.loss == 0.42
+
+    def test_all_fields_populated(self):
+        """Test TrainingContext with all fields explicitly set."""
+        ctx = TrainingContext(
+            hook_name="on_step_end",
+            step=42,
+            epoch=2,
+            total_samples=1000,
+            total_tokens=50000,
+            loss=0.5,
+            learning_rate=1e-4,
+            grad_norm=1.2,
+            batch_metrics={"loss": 0.5, "lr": 1e-4},
+            val_metrics={"val_loss": 0.6},
+            checkpoint_path="/tmp/ckpt",
+            output_dir="/tmp/output",
+            model_name_or_path="meta-llama/Llama-3.1-8B",
+            training_mode="epoch",
+            max_epochs=3,
+            max_steps=0,
+            max_tokens=0,
+            world_size=8,
+        )
+        assert ctx.step == 42
+        assert ctx.total_tokens == 50000
+        assert ctx.checkpoint_path == "/tmp/ckpt"
+
+
+class _StepRecorderCallback(TrainerCallback):
+    def __init__(self):
+        self.event = threading.Event()
+        self.captured = {}
+
+    def on_train_begin(self, context):
+        self.captured["step"] = context.step
+        self.captured["hook"] = context.hook_name
+        self.event.set()
+
+
+class _SignalCallback(TrainerCallback):
+    def __init__(self):
+        self.event = threading.Event()
+
+    def on_step_end(self, context):
+        self.event.set()
+
+
+class _ExplodingCallback(TrainerCallback):
+    def __init__(self):
+        self.event = threading.Event()
+
+    def on_step_end(self, context):
+        self.event.set()
+        raise RuntimeError("boom")
+
+    def on_log(self, context):
+        self.event.set()
+        raise ValueError("test error 12345")
+
+
+class _AsyncCallback(TrainerCallback):
+    def __init__(self):
+        self.event = threading.Event()
+        self.captured = {}
+
+    async def on_epoch_end(self, context):
+        self.captured["step"] = context.step
+        self.event.set()
+
+
+class _SlowTrainEndCallback(TrainerCallback):
+    def __init__(self):
+        self.result = {}
+
+    def on_train_end(self, context):
+        time.sleep(0.5)
+        self.result["done"] = True
+
+
+class _SaveRecorderCallback(TrainerCallback):
+    def __init__(self):
+        self.event = threading.Event()
+        self.captured = {}
+
+    def on_save(self, context):
+        self.captured["checkpoint_path"] = context.checkpoint_path
+        self.captured["step"] = context.step
+        self.event.set()
+
+
+class _StepEndRecorderCallback(TrainerCallback):
+    def __init__(self):
+        self.event = threading.Event()
+        self.captured = {}
+
+    def on_step_end(self, context):
+        self.captured["step"] = context.step
+        self.event.set()
+
+
+class _MultiHookCallback(TrainerCallback):
+    """Callback that implements multiple hooks."""
+
+    def __init__(self):
+        self.events = []
+        self.done = threading.Event()
+
+    def on_train_begin(self, context):
+        self.events.append("on_train_begin")
+
+    def on_log(self, context):
+        self.events.append("on_log")
+
+    def on_train_end(self, context):
+        self.events.append("on_train_end")
+        self.done.set()
+
+
+class TestCallbackManager:
+    """Test suite for CallbackManager dispatch and lifecycle."""
+
+    def test_add_callback(self):
+        """Test adding a TrainerCallback instance."""
+        mgr = CallbackManager(is_rank_0=True)
+        cb = _SignalCallback()
+        mgr.add_callback(cb)
+        assert mgr.has_callbacks("on_step_end")
+
+    def test_add_callback_rejects_non_instance(self):
+        """Test that passing a class instead of an instance raises TypeError."""
+        mgr = CallbackManager(is_rank_0=True)
+        with pytest.raises(TypeError, match="Expected a TrainerCallback instance"):
+            mgr.add_callback(_SignalCallback)
+
+    def test_remove_callback_by_instance(self):
+        """Test removing a specific callback instance."""
+        mgr = CallbackManager(is_rank_0=True)
+        cb = _SignalCallback()
+        mgr.add_callback(cb)
+        assert mgr.has_callbacks("on_step_end")
+        mgr.remove_callback(cb)
+        assert not mgr.has_callbacks("on_step_end")
+
+    def test_remove_callback_by_type(self):
+        """Test removing all callbacks of a given type."""
+        mgr = CallbackManager(is_rank_0=True)
+        mgr.add_callback(_SignalCallback())
+        mgr.add_callback(_SignalCallback())
+        assert mgr.has_callbacks("on_step_end")
+        mgr.remove_callback(_SignalCallback)
+        assert not mgr.has_callbacks("on_step_end")
+
+    def test_fire_invokes_callback(self):
+        """Test that fire() dispatches the callback with correct context."""
+        cb = _StepRecorderCallback()
+        mgr = CallbackManager(is_rank_0=True)
+        mgr.context.step = 7
+        mgr.add_callback(cb)
+        mgr.fire("on_train_begin")
+        assert cb.event.wait(timeout=5), "Callback was not invoked within timeout"
+        assert cb.captured["step"] == 7
+        assert cb.captured["hook"] == "on_train_begin"
+
+    def test_fire_multiple_callbacks(self):
+        """Test that fire() invokes all registered callbacks for a hook."""
+        cb1 = _SignalCallback()
+        cb2 = _SignalCallback()
+        mgr = CallbackManager(is_rank_0=True)
+        mgr.add_callback(cb1)
+        mgr.add_callback(cb2)
+        mgr.fire("on_step_end")
+        assert cb1.event.wait(timeout=5)
+        assert cb2.event.wait(timeout=5)
+
+    def test_fire_rank0_only(self):
+        """Test that callbacks are suppressed on non-rank-0 processes."""
+        cb = _SignalCallback()
+        mgr = CallbackManager(is_rank_0=False)
+        mgr.add_callback(cb)
+        mgr.fire("on_step_end")
+        time.sleep(0.2)
+        assert not cb.event.is_set(), "Callback should not fire on non-rank-0"
+
+    def test_fire_exception_swallowed(self):
+        """Test that callback exceptions do not propagate to the caller."""
+        cb = _ExplodingCallback()
+        mgr = CallbackManager(is_rank_0=True)
+        mgr.add_callback(cb)
+        mgr.fire("on_step_end")
+        assert cb.event.wait(timeout=5), "Callback should have been invoked"
+        time.sleep(0.1)
+
+    def test_fire_exception_logged(self):
+        """Test that callback exceptions are logged with the error message."""
+        cb = _ExplodingCallback()
+        logged_messages = []
+
+        class CaptureHandler(logging.Handler):
+            def emit(self, record):
+                logged_messages.append(self.format(record))
+
+        cb_logger = logging.getLogger("mini_trainer.callbacks")
+        handler = CaptureHandler()
+        cb_logger.addHandler(handler)
+        cb_logger.setLevel(logging.ERROR)
+        try:
+            mgr = CallbackManager(is_rank_0=True)
+            mgr.add_callback(cb)
+            mgr.fire("on_log")
+            cb.event.wait(timeout=5)
+            time.sleep(0.3)
+            assert any("test error 12345" in msg for msg in logged_messages)
+        finally:
+            cb_logger.removeHandler(handler)
+
+    def test_has_callbacks_detects_overridden(self):
+        """Test has_callbacks() returns True only for overridden hooks."""
+        mgr = CallbackManager(is_rank_0=True)
+        mgr.add_callback(_SignalCallback())
+        assert mgr.has_callbacks("on_step_end")
+        assert not mgr.has_callbacks("on_train_begin")
+        assert not mgr.has_callbacks("on_log")
+
+    def test_has_callbacks_no_callbacks(self):
+        """Test has_callbacks() returns False when no callbacks registered."""
+        mgr = CallbackManager(is_rank_0=True)
+        assert not mgr.has_callbacks("on_train_begin")
+
+    def test_fire_no_callbacks_is_noop(self):
+        """Test that fire() with no registered callbacks is a safe no-op."""
+        mgr = CallbackManager(is_rank_0=True)
+        mgr.fire("on_train_begin")
+
+    def test_async_callback_support(self):
+        """Test that async (coroutine) callbacks are awaited correctly."""
+        cb = _AsyncCallback()
+        mgr = CallbackManager(is_rank_0=True)
+        mgr.context.step = 99
+        mgr.add_callback(cb)
+        mgr.fire("on_epoch_end")
+        assert cb.event.wait(timeout=5)
+        assert cb.captured["step"] == 99
+
+    def test_on_train_end_waits_for_completion(self):
+        """Test that on_train_end blocks until callbacks finish."""
+        cb = _SlowTrainEndCallback()
+        mgr = CallbackManager(is_rank_0=True)
+        mgr.add_callback(cb)
+        mgr.fire("on_train_end")
+        assert cb.result.get("done"), "on_train_end should wait for callback to complete"
+
+    def test_fire_kwargs_override_context(self):
+        """Test that kwargs passed to fire() override context fields in the snapshot."""
+        cb = _SaveRecorderCallback()
+        mgr = CallbackManager(is_rank_0=True)
+        mgr.context.step = 10
+        mgr.context.checkpoint_path = None
+        mgr.add_callback(cb)
+        mgr.fire("on_save", checkpoint_path="/tmp/ckpt-10")
+        assert cb.event.wait(timeout=5)
+        assert cb.captured["checkpoint_path"] == "/tmp/ckpt-10"
+        assert cb.captured["step"] == 10
+        assert mgr.context.checkpoint_path is None, "kwargs should not mutate the shared context"
+
+    def test_snapshot_isolation(self):
+        """Test that callbacks receive a snapshot, not a reference to the shared context."""
+        cb = _StepEndRecorderCallback()
+        mgr = CallbackManager(is_rank_0=True)
+        mgr.context.step = 42
+        mgr.add_callback(cb)
+        mgr.fire("on_step_end")
+        mgr.context.step = 999
+        assert cb.event.wait(timeout=5)
+        assert cb.captured["step"] == 42, "Callback should see the step value at fire() time"
+
+    def test_multi_hook_callback(self):
+        """Test that a single callback can implement multiple hooks."""
+        cb = _MultiHookCallback()
+        mgr = CallbackManager(is_rank_0=True)
+        mgr.add_callback(cb)
+        mgr.fire("on_train_begin")
+        mgr.fire("on_log")
+        mgr.fire("on_train_end")
+        assert cb.done.wait(timeout=5)
+        assert "on_train_begin" in cb.events
+        assert "on_log" in cb.events
+        assert "on_train_end" in cb.events
+
+
+class _StandaloneCallback(TrainerCallback):
+    def on_train_begin(self, context):
+        import os
+
+        _ = os.getpid()
+
+
+class _InlineImportCallback(TrainerCallback):
+    def on_log(self, context):
+        import json
+
+        _ = json.dumps({"step": context.step})
+
+
+class TestSerialization:
+    """Test suite for callback serialization across the torchrun subprocess boundary."""
+
+    def test_serialize_deserialize_roundtrip(self):
+        """Test single callback serialize/deserialize round-trip."""
+        original = _StandaloneCallback()
+        encoded = serialize_callback(original)
+        restored = deserialize_callback(encoded)
+        assert isinstance(restored, TrainerCallback)
+        ctx = TrainingContext(hook_name="test")
+        restored.on_train_begin(ctx)
+
+    def test_serialize_self_contained_callback(self):
+        """Test serialization of a callback with inline imports."""
+        original = _InlineImportCallback()
+        encoded = serialize_callback(original)
+        restored = deserialize_callback(encoded)
+        ctx = TrainingContext(hook_name="test", step=42)
+        restored.on_log(ctx)
+
+    def test_serialize_callbacks_for_cli_roundtrip(self):
+        """Test full callbacks list serialize/deserialize for CLI transport."""
+        cb1 = _StandaloneCallback()
+        cb2 = _InlineImportCallback()
+        encoded = serialize_callbacks_for_cli([cb1, cb2])
+        decoded = deserialize_callbacks_from_cli(encoded)
+        assert len(decoded) == 2
+        assert all(isinstance(cb, TrainerCallback) for cb in decoded)
+        ctx = TrainingContext(hook_name="test")
+        decoded[0].on_train_begin(ctx)
+        decoded[1].on_log(ctx)
+
+    def test_deserialize_invalid_base64(self):
+        """Test that invalid base64 input raises an exception."""
+        with pytest.raises(Exception):
+            deserialize_callback("not-valid-base64!!!")
+
+    def test_empty_callbacks_list(self):
+        """Test serialization of an empty callbacks list."""
+        encoded = serialize_callbacks_for_cli([])
+        decoded = deserialize_callbacks_from_cli(encoded)
+        assert decoded == []
+
+
+class TestApiTrainSerialization:
+    """Test suite for callback integration with TrainingArgs and api_train."""
+
+    def test_training_args_with_callbacks(self):
+        """Test that TrainingArgs accepts a list of TrainerCallback instances."""
+        from mini_trainer.training_types import TrainingArgs
+
+        class MyCallback(TrainerCallback):
+            def on_train_begin(self, context):
+                pass
+
+        args = TrainingArgs(
+            model_name_or_path="test-model",
+            data_path="test.jsonl",
+            batch_size=4,
+            max_tokens_per_gpu=1024,
+            learning_rate=1e-4,
+            output_dir="/tmp/test_output",
+            callbacks=[MyCallback()],
+        )
+        assert args.callbacks is not None
+        assert len(args.callbacks) == 1
+        assert isinstance(args.callbacks[0], TrainerCallback)
+
+    def test_training_args_no_callbacks_default(self):
+        """Test that callbacks defaults to None when not provided."""
+        from mini_trainer.training_types import TrainingArgs
+
+        args = TrainingArgs(
+            model_name_or_path="test-model",
+            data_path="test.jsonl",
+            batch_size=4,
+            max_tokens_per_gpu=1024,
+            learning_rate=1e-4,
+            output_dir="/tmp/test_output",
+        )
+        assert args.callbacks is None


### PR DESCRIPTION
## Summary

- Adds a `TrainerCallback` base class with 13 lifecycle hooks that users subclass and override
- Callbacks are async fire-and-forget, dispatched on a background event loop. Exceptions are logged but never propagated to the training loop
- Callbacks fire on all ranks. `context.is_world_process_zero` and `context.is_local_process_zero` let each callback decide its own rank behavior
- Callback classes are serialized via `inspect.getsource()` + base64 to cross the torchrun subprocess boundary
- `CallbackManager` snapshots a `TrainingContext` before dispatch so callbacks see a consistent, frozen view

Closes #76

## Flow

```mermaid
sequenceDiagram
    participant CallerProcess
    participant run_training
    participant torchrun
    participant main_CLI
    participant train
    participant CallbackManager
    participant BackgroundEventLoop

    rect rgba(70, 130, 180, 0.5)
        Note over CallerProcess, run_training: API layer
        CallerProcess->>run_training: TrainingArgs(callbacks=[cb1, cb2])
        run_training->>run_training: serialize_callbacks_for_cli() → base64
        run_training->>torchrun: spawn --serialized-callbacks=base64
    end

    rect rgba(60, 179, 113, 0.5)
        Note over torchrun, train: Worker process
        torchrun->>main_CLI: --serialized-callbacks arg
        main_CLI->>main_CLI: deserialize_callbacks_from_cli() → [cb1, cb2]
        main_CLI->>main_CLI: build CallbackManager, add callbacks
        main_CLI->>train: train(..., callback_manager)
    end

    rect rgba(178, 102, 255, 0.5)
        Note over train, BackgroundEventLoop: Training loop dispatch
        train->>CallbackManager: fire("on_train_begin")
        train->>CallbackManager: fire("on_step_begin") per step
        train->>CallbackManager: fire("on_before_forward") per minibatch
        train->>CallbackManager: fire("on_after_backward") per minibatch
        train->>CallbackManager: fire("on_optimizer_step")
        train->>CallbackManager: fire("on_save", checkpoint_path=...)
        train->>CallbackManager: fire("on_train_end") — blocks with timeout
        CallbackManager->>BackgroundEventLoop: schedule async hook invocations
        BackgroundEventLoop-->>CallbackManager: exception caught + logged
    end
```

## Files changed

- **`src/mini_trainer/callbacks.py`** (new): `TrainerCallback`, `CallbackManager`, `TrainingContext`, serialization utilities
- **`src/mini_trainer/train.py`**: 13 hook call sites wired into the training loop
- **`src/mini_trainer/api_train.py`**: Serializes callbacks for CLI transport to torchrun subprocesses
- **`src/mini_trainer/training_types.py`**: `TrainingArgs.callbacks` field (`list | None`)
- **`src/mini_trainer/__init__.py`**: Exports `TrainerCallback`, `CallbackManager`, `TrainingContext`
- **`tests/test_callbacks.py`** (new): 28 tests covering dispatch, rank behavior, serialization, snapshot isolation

## Test plan

- [x] `pytest tests/test_callbacks.py -v` — 28 tests pass
- [ ] Manual test with `run_training()` + a custom callback on multi-GPU

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a callback system for training lifecycle events including epoch and step milestones, forward/backward passes, optimizer steps, evaluation, logging, and checkpoint saves.
  * Callbacks are now accessible via the updated public API.

* **Tests**
  * Added comprehensive test suite validating callback registration, dispatch, serialization, and training loop integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
**Jira:** [RHOAIENG-57774](https://redhat.atlassian.net/browse/RHOAIENG-57774)