### PR TITLE
fix: pin datasets>=5.0.0 to resolve pyarrow compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "aiofiles",
     "deprecated",
     "numpy",
-    "datasets",
+    "datasets>=5.0.0",
     "transformers>=4.57.1",
     "ninja",
     "numba>=0.61.2",


### PR DESCRIPTION
## Summary

- Pins `datasets>=5.0.0` in `pyproject.toml` to fix the `pyarrow.PyExtensionType` `AttributeError` that breaks all test collection when mini_trainer is installed standalone
- The unpinned `datasets` allowed the resolver to install `datasets==2.14.4` alongside `pyarrow==24.0.0`, which are incompatible (`PyExtensionType` was removed in pyarrow 21)
- `datasets 5.0.0` is compatible with `pyarrow 24` and resolves both the `PyExtensionType` and `LocalFileSystem` test failures
- This aligns mini_trainer's standalone install with the version that training_hub already resolves

## Test plan

- Validated by @mini-trainer-validator on A100: fresh clone + `uv pip install -e "."` with this pin resolves to `datasets==5.0.0` + `pyarrow==24.0.0`, all 305 tests pass on `main` and 333 pass on PR #109 branch (28 new callback tests)
- CI should now pass without the pyarrow collection errors

Fixes the pre-existing CI breakage discussed in MT-38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum version requirement for the datasets dependency to 5.0.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->