### PR TITLE
Fix lint errors and test failures on main

### DIFF
--- a/src/mini_trainer/train.py
+++ b/src/mini_trainer/train.py
@@ -836,7 +836,7 @@ def train(
     # control args
     world_size = int(os.environ["WORLD_SIZE"])
     is_local_main_process = int(os.getenv("LOCAL_RANK", 0)) == 0
-    is_main_process = int(os.getenv("RANK", 0)) == 0
+    is_main_process = dist.get_rank() == 0
     metric_logger = AsyncStructuredLogger(
         output_dir + f"/training_metrics_{get_node_rank()}.jsonl",
         use_wandb=use_wandb,

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -394,7 +394,7 @@ class TestSerialization:
 
     def test_deserialize_invalid_base64(self):
         """Test that invalid base64 input raises an exception."""
-        with pytest.raises(Exception):
+        with pytest.raises((ValueError, UnicodeDecodeError)):
             deserialize_callback("not-valid-base64!!!")
 
     def test_empty_callbacks_list(self):

--- a/tests/test_osft.py
+++ b/tests/test_osft.py
@@ -2337,10 +2337,10 @@ class TestPostStepParameterProjection:
                 # Add a component in the frozen subspace direction
                 with torch.no_grad():
                     module.osft_params.U_low.data += U_high @ torch.randn(
-                        U_high.shape[1], module.osft_params.U_low.shape[1]
+                        U_high.shape[1], module.osft_params.U_low.shape[1], device=U_high.device
                     )
                     module.osft_params.V_low.data += (
-                        torch.randn(module.osft_params.V_low.shape[0], V_high.shape[0]) @ V_high
+                        torch.randn(module.osft_params.V_low.shape[0], V_high.shape[0], device=V_high.device) @ V_high
                     )
 
         # Now project parameters
@@ -2518,7 +2518,9 @@ class TestPostStepParameterProjection:
             if hasattr(module, "osft_params") and hasattr(module, "osft_U_high"):
                 with torch.no_grad():
                     module.osft_params.U_low.data += module.osft_U_high @ torch.randn(
-                        module.osft_U_high.shape[1], module.osft_params.U_low.shape[1]
+                        module.osft_U_high.shape[1],
+                        module.osft_params.U_low.shape[1],
+                        device=module.osft_U_high.device,
                     )
 
         # First projection


### PR DESCRIPTION
## Summary

- **`train.py`**: Fix undefined `is_main_process` in `train()` callback context setup
- **`callbacks.py`**: Remove stale `noqa` directive, apply `ruff format`
- **`test_callbacks.py`**: Remove unused import, narrow broad `pytest.raises(Exception)`
- **`test_osft.py`**: Fix device mismatch in parameter projection tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved distributed training behavior by consistently identifying the primary process across multi-process runs.
  * Prevented device mismatch errors during parameter projection checks on CPU and GPU setups.
  * Tightened invalid encoded-data validation to report only expected decoding errors.

* **Tests**
  * Updated automated coverage for distributed execution, decoding validation, and device-aware parameter projections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->