### PR TITLE
feat: add --validation-data-path for loading a separate eval dataset

### DIFF
--- a/src/mini_trainer/api_train.py
+++ b/src/mini_trainer/api_train.py
@@ -149,7 +149,7 @@ def run_training(torch_args: TorchrunArgs, train_args: TrainingArgs) -> None:
             command.append(f"--mlflow-run-name={train_args.mlflow_run_name}")
 
     # validation-related arguments
-    if train_args.validation_data_path:
+    if train_args.validation_data_path is not None:
         command.append(f"--validation-data-path={train_args.validation_data_path}")
     if train_args.validation_split > 0.0:
         command.append(f"--validation-split={train_args.validation_split}")

--- a/src/mini_trainer/api_train.py
+++ b/src/mini_trainer/api_train.py
@@ -149,8 +149,13 @@ def run_training(torch_args: TorchrunArgs, train_args: TrainingArgs) -> None:
             command.append(f"--mlflow-run-name={train_args.mlflow_run_name}")
 
     # validation-related arguments
+    if train_args.validation_data_path:
+        command.append(f"--validation-data-path={train_args.validation_data_path}")
     if train_args.validation_split > 0.0:
         command.append(f"--validation-split={train_args.validation_split}")
+
+    has_validation = train_args.validation_split > 0.0 or train_args.validation_data_path is not None
+    if has_validation:
         if train_args.validation_frequency is not None:
             command.append(f"--validation-frequency={train_args.validation_frequency}")
 

--- a/src/mini_trainer/callbacks.py
+++ b/src/mini_trainer/callbacks.py
@@ -78,19 +78,44 @@ class TrainerCallback:
     constructors must work with no arguments (or all-default arguments).
     """
 
-    def on_train_begin(self, context: TrainingContext) -> None: pass
-    def on_epoch_begin(self, context: TrainingContext) -> None: pass
-    def on_step_begin(self, context: TrainingContext) -> None: pass
-    def on_before_forward(self, context: TrainingContext) -> None: pass
-    def on_after_backward(self, context: TrainingContext) -> None: pass
-    def on_pre_optimizer_step(self, context: TrainingContext) -> None: pass
-    def on_optimizer_step(self, context: TrainingContext) -> None: pass
-    def on_log(self, context: TrainingContext) -> None: pass
-    def on_evaluate(self, context: TrainingContext) -> None: pass
-    def on_save(self, context: TrainingContext) -> None: pass
-    def on_step_end(self, context: TrainingContext) -> None: pass
-    def on_epoch_end(self, context: TrainingContext) -> None: pass
-    def on_train_end(self, context: TrainingContext) -> None: pass
+    def on_train_begin(self, context: TrainingContext) -> None:
+        pass
+
+    def on_epoch_begin(self, context: TrainingContext) -> None:
+        pass
+
+    def on_step_begin(self, context: TrainingContext) -> None:
+        pass
+
+    def on_before_forward(self, context: TrainingContext) -> None:
+        pass
+
+    def on_after_backward(self, context: TrainingContext) -> None:
+        pass
+
+    def on_pre_optimizer_step(self, context: TrainingContext) -> None:
+        pass
+
+    def on_optimizer_step(self, context: TrainingContext) -> None:
+        pass
+
+    def on_log(self, context: TrainingContext) -> None:
+        pass
+
+    def on_evaluate(self, context: TrainingContext) -> None:
+        pass
+
+    def on_save(self, context: TrainingContext) -> None:
+        pass
+
+    def on_step_end(self, context: TrainingContext) -> None:
+        pass
+
+    def on_epoch_end(self, context: TrainingContext) -> None:
+        pass
+
+    def on_train_end(self, context: TrainingContext) -> None:
+        pass
 
 
 class CallbackManager:
@@ -209,9 +234,10 @@ def deserialize_callback(encoded: str) -> TrainerCallback:
     source = base64.b64decode(encoded).decode("utf-8")
     namespace: dict[str, Any] = {"TrainerCallback": TrainerCallback, "TrainingContext": TrainingContext}
     # Only called with source from api_train.py serialization, never untrusted input
-    exec(source, namespace)  # noqa: S102
+    exec(source, namespace)
     classes = [
-        v for v in namespace.values()
+        v
+        for v in namespace.values()
         if isinstance(v, type) and issubclass(v, TrainerCallback) and v is not TrainerCallback
     ]
     if len(classes) != 1:

--- a/src/mini_trainer/sampler.py
+++ b/src/mini_trainer/sampler.py
@@ -676,7 +676,7 @@ def get_data_loader(
     if validation_split < 0.0 or validation_split >= 1.0:
         raise ValueError(f"validation_split must be between 0 and 1 (exclusive of 1), got {validation_split}")
 
-    if validation_data_path and validation_split > 0.0:
+    if validation_data_path is not None and validation_split > 0.0:
         raise ValueError("validation_data_path and validation_split are mutually exclusive")
 
     # Create dataset based on mode

--- a/src/mini_trainer/sampler.py
+++ b/src/mini_trainer/sampler.py
@@ -642,6 +642,7 @@ def get_data_loader(
     dummy_sample: dict | None = None,
     num_workers: int = 0,
     validation_split: float = 0.0,
+    validation_data_path: str | None = None,
     max_seq_len: int | None = None,
     pretraining_config: PretrainingConfig | None = None,
     pad_token_id: int = 0,
@@ -661,17 +662,22 @@ def get_data_loader(
         dummy_sample: Sample to use for padding when ranks have uneven data
         num_workers: Number of worker processes for data loading
         validation_split: Fraction of data to use for validation (0.0 to 1.0)
+        validation_data_path: Path to a separate validation dataset (JSONL).
+            Mutually exclusive with validation_split.
         max_seq_len: Maximum sequence length to keep (filters out longer sequences)
         pretraining_config: Configuration for pretraining mode. If provided, enables
             pretraining with block-based sampling.
         pad_token_id: Token id to use for padding in padded batches.
     Returns:
         tuple: (train_loader, val_loader) where val_loader is None if validation_split <= 0
-            or if in pretraining mode
+            and validation_data_path is None
     """
     # Validate parameters
     if validation_split < 0.0 or validation_split >= 1.0:
         raise ValueError(f"validation_split must be between 0 and 1 (exclusive of 1), got {validation_split}")
+
+    if validation_data_path and validation_split > 0.0:
+        raise ValueError("validation_data_path and validation_split are mutually exclusive")
 
     # Create dataset based on mode
     if pretraining_config is not None:
@@ -702,6 +708,26 @@ def get_data_loader(
             log_rank_0(f"Dataset split: {len(train_dataset)} train, {len(val_dataset)} validation samples")
         else:
             log_rank_0(f"Dataset split: {len(train_dataset)} train")
+
+    # Load a separate validation dataset if provided (overrides split-based val_dataset)
+    if validation_data_path is not None:
+        if pretraining_config is not None:
+            separate_val, _ = PretrainingBlockDataset.load_and_split(
+                data_path=validation_data_path,
+                block_size=pretraining_config.block_size,
+                pad_token_id=pad_token_id,
+                validation_split=0.0,
+                seed=seed,
+            )
+        else:
+            separate_val, _ = JsonlDataset.load_and_split(
+                data_path=validation_data_path,
+                validation_split=0.0,
+                max_seq_len=max_seq_len,
+                seed=seed,
+            )
+        val_dataset = separate_val
+        log_rank_0(f"Loaded separate validation dataset: {len(val_dataset)} samples from {validation_data_path}")
 
     # Create collate function
     collate_fn = MaxTokensPerRankCollator(

--- a/src/mini_trainer/train.py
+++ b/src/mini_trainer/train.py
@@ -741,6 +741,7 @@ def train(
     # control args
     world_size = int(os.environ["WORLD_SIZE"])
     is_local_main_process = int(os.getenv("LOCAL_RANK", 0)) == 0
+    is_main_process = int(os.getenv("RANK", 0)) == 0
     metric_logger = AsyncStructuredLogger(
         output_dir + f"/training_metrics_{get_node_rank()}.jsonl",
         use_wandb=use_wandb,
@@ -1342,7 +1343,9 @@ def main(
     ] = None,
     validation_frequency: Annotated[
         int | None,
-        Option(help="Frequency of validation evaluation (in steps). Required when validation_split > 0 or validation_data_path is provided"),
+        Option(
+            help="Frequency of validation evaluation (in steps). Required when validation_split > 0 or validation_data_path is provided"
+        ),
     ] = None,
     # checkpoint parameters
     save_best_val_loss: Annotated[
@@ -1421,7 +1424,7 @@ def main(
     if validation_split < 0.0 or validation_split >= 1.0:
         raise ValueError("validation_split must be between 0.0 and 1.0 (exclusive)")
 
-    if validation_data_path and validation_split > 0.0:
+    if validation_data_path is not None and validation_split > 0.0:
         raise ValueError("validation_data_path and validation_split are mutually exclusive")
 
     has_validation = validation_split > 0.0 or validation_data_path is not None
@@ -1593,7 +1596,7 @@ def main(
     )
 
     if val_data_loader is not None:
-        if validation_data_path:
+        if validation_data_path is not None:
             log_rank_0(f"Using separate validation dataset from {validation_data_path}")
         else:
             log_rank_0(f"Created train/validation split with {validation_split:.1%} validation data")

--- a/src/mini_trainer/train.py
+++ b/src/mini_trainer/train.py
@@ -1336,9 +1336,13 @@ def main(
     ] = "float32",
     # validation parameters
     validation_split: Annotated[float, Option(help="Fraction of data to use for validation (0.0 to 1.0)")] = 0.0,
+    validation_data_path: Annotated[
+        str | None,
+        Option(help="Path to a separate validation dataset (JSONL). Mutually exclusive with validation_split"),
+    ] = None,
     validation_frequency: Annotated[
         int | None,
-        Option(help="Frequency of validation evaluation (in steps). Required when validation_split > 0"),
+        Option(help="Frequency of validation evaluation (in steps). Required when validation_split > 0 or validation_data_path is provided"),
     ] = None,
     # checkpoint parameters
     save_best_val_loss: Annotated[
@@ -1417,8 +1421,12 @@ def main(
     if validation_split < 0.0 or validation_split >= 1.0:
         raise ValueError("validation_split must be between 0.0 and 1.0 (exclusive)")
 
-    if validation_split > 0.0 and (validation_frequency is None or validation_frequency <= 0):
-        raise ValueError("validation_frequency must be provided and positive when validation_split > 0")
+    if validation_data_path and validation_split > 0.0:
+        raise ValueError("validation_data_path and validation_split are mutually exclusive")
+
+    has_validation = validation_split > 0.0 or validation_data_path is not None
+    if has_validation and (validation_frequency is None or validation_frequency <= 0):
+        raise ValueError("validation_frequency must be provided and positive when using validation")
 
     # Convert string dtypes to torch dtypes
     osft_upcast_dtype_torch = parse_dtype(osft_upcast_dtype)
@@ -1460,6 +1468,7 @@ def main(
             "checkpoint_at_epoch": checkpoint_at_epoch,
             "save_final_checkpoint": save_final_checkpoint,
             "validation_split": validation_split,
+            "validation_data_path": validation_data_path,
             "validation_frequency": validation_frequency,
             "save_best_val_loss": save_best_val_loss,
             "val_loss_improvement_threshold": val_loss_improvement_threshold,
@@ -1579,11 +1588,15 @@ def main(
         seed=seed,
         pad_token_id=getattr(getattr(model.config, "text_config", model.config), "pad_token_id", None),
         validation_split=validation_split,
+        validation_data_path=validation_data_path,
         pretraining_config=pretraining_config,
     )
 
-    if validation_split > 0.0:
-        log_rank_0(f"Created train/validation split with {validation_split:.1%} validation data")
+    if val_data_loader is not None:
+        if validation_data_path:
+            log_rank_0(f"Using separate validation dataset from {validation_data_path}")
+        else:
+            log_rank_0(f"Created train/validation split with {validation_split:.1%} validation data")
         log_rank_0(f"Validation data loader length: {len(val_data_loader)}")
         log_rank_0(f"Training data loader length: {len(data_loader)}")
     else:

--- a/src/mini_trainer/training_types.py
+++ b/src/mini_trainer/training_types.py
@@ -183,9 +183,15 @@ class TrainingArgs:
             "help": "The fraction of data to use for validation. 0.0 means no validation, 0.1 means 10% of the data is used for validation."
         },
     )
+    validation_data_path: str | None = field(
+        default=None,
+        metadata={
+            "help": "Path to a separate validation dataset (JSONL). Mutually exclusive with validation_split."
+        },
+    )
     validation_frequency: int | None = field(
         default=None,
-        metadata={"help": "The frequency of validation in steps. Required when validation_split > 0."},
+        metadata={"help": "The frequency of validation in steps. Required when validation_split > 0 or validation_data_path is provided."},
     )
 
     # Pretraining configuration (None = instruction tuning, non-None = pretraining)

--- a/src/mini_trainer/training_types.py
+++ b/src/mini_trainer/training_types.py
@@ -185,13 +185,13 @@ class TrainingArgs:
     )
     validation_data_path: str | None = field(
         default=None,
-        metadata={
-            "help": "Path to a separate validation dataset (JSONL). Mutually exclusive with validation_split."
-        },
+        metadata={"help": "Path to a separate validation dataset (JSONL). Mutually exclusive with validation_split."},
     )
     validation_frequency: int | None = field(
         default=None,
-        metadata={"help": "The frequency of validation in steps. Required when validation_split > 0 or validation_data_path is provided."},
+        metadata={
+            "help": "The frequency of validation in steps. Required when validation_split > 0 or validation_data_path is provided."
+        },
     )
 
     # Pretraining configuration (None = instruction tuning, non-None = pretraining)

--- a/tests/test_api_train.py
+++ b/tests/test_api_train.py
@@ -525,6 +525,35 @@ class TestRunTraining:
             assert "--osft-unfreeze-rank-ratio=0.3" in command
 
     @patch("mini_trainer.api_train.StreamablePopen")
+    def test_run_training_validation_data_path(self, mock_popen_class):
+        """Test that validation_data_path is forwarded to the training command."""
+        mock_popen = MagicMock()
+        mock_popen.poll.return_value = 0
+        mock_popen_class.return_value = mock_popen
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            torch_args = TorchrunArgs(nproc_per_node=1)
+            train_args = TrainingArgs(
+                model_name_or_path="test-model",
+                data_path="train.jsonl",
+                batch_size=32,
+                max_tokens_per_gpu=1000,
+                learning_rate=1e-5,
+                output_dir=tmpdir,
+                validation_data_path="/data/eval.jsonl",
+                validation_frequency=10,
+            )
+
+            run_training(torch_args, train_args)
+
+            call_args = mock_popen_class.call_args
+            _, command = call_args[0]
+            assert "--validation-data-path=/data/eval.jsonl" in command
+            assert "--validation-frequency=10" in command
+            # Should NOT have validation-split since it's 0.0
+            assert not any(arg.startswith("--validation-split=") for arg in command)
+
+    @patch("mini_trainer.api_train.StreamablePopen")
     def test_run_training_keyboard_interrupt(self, mock_popen_class):
         """Test that run_training handles keyboard interrupt properly."""
         mock_popen = MagicMock()

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -6,7 +6,6 @@ context with snapshot isolation, class-based interface, and serialization
 for crossing the torchrun subprocess boundary.
 """
 
-import asyncio
 import logging
 import threading
 import time

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -1018,6 +1018,100 @@ class TestGetDataLoader:
         finally:
             os.unlink(temp_path)
 
+    def test_validation_data_path_loads_separate_dataset(self, temp_data_file):
+        """Test that validation_data_path loads a separate dataset for validation."""
+        val_data = [
+            {
+                "input_ids": list(range(50, 80)),
+                "labels": list(range(50, 80)),
+                "len": 30,
+                "num_loss_counted_tokens": 30,
+            }
+            for _ in range(5)
+        ]
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
+            for item in val_data:
+                json.dump(item, f)
+                f.write("\n")
+            val_path = f.name
+
+        try:
+            train_loader, val_loader = get_data_loader(
+                data_path=temp_data_file,
+                batch_size=2,
+                max_tokens_per_gpu=500,
+                seed=42,
+                validation_data_path=val_path,
+                rank=0,
+                world_size=1,
+            )
+
+            assert train_loader is not None
+            assert val_loader is not None
+            assert len(train_loader.dataset) == 10
+            assert len(val_loader.dataset) == 5
+        finally:
+            os.unlink(val_path)
+
+    def test_validation_data_path_and_split_mutually_exclusive(self, temp_data_file):
+        """Test that providing both validation_data_path and validation_split raises an error."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
+            json.dump({"input_ids": [1, 2], "labels": [1, 2], "len": 2, "num_loss_counted_tokens": 2}, f)
+            val_path = f.name
+
+        try:
+            with pytest.raises(
+                ValueError,
+                match="validation_data_path and validation_split are mutually exclusive",
+            ):
+                get_data_loader(
+                    data_path=temp_data_file,
+                    batch_size=2,
+                    max_tokens_per_gpu=500,
+                    seed=42,
+                    validation_split=0.2,
+                    validation_data_path=val_path,
+                    rank=0,
+                    world_size=1,
+                )
+        finally:
+            os.unlink(val_path)
+
+    def test_validation_data_path_without_split_uses_all_train_data(self, temp_data_file):
+        """Test that validation_data_path does not split training data."""
+        val_data = [
+            {
+                "input_ids": list(range(200, 210)),
+                "labels": list(range(200, 210)),
+                "len": 10,
+                "num_loss_counted_tokens": 10,
+            }
+            for _ in range(3)
+        ]
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
+            for item in val_data:
+                json.dump(item, f)
+                f.write("\n")
+            val_path = f.name
+
+        try:
+            train_loader, val_loader = get_data_loader(
+                data_path=temp_data_file,
+                batch_size=2,
+                max_tokens_per_gpu=500,
+                seed=42,
+                validation_data_path=val_path,
+                rank=0,
+                world_size=1,
+            )
+
+            # All 10 samples should be in training (no split)
+            assert len(train_loader.dataset) == 10
+            # Validation should have the 3 samples from the separate file
+            assert len(val_loader.dataset) == 3
+        finally:
+            os.unlink(val_path)
+
 
 class TestResetMinibatches:
     """Test suite for the reset_minibatches utility function."""


### PR DESCRIPTION
## Summary
- Adds `--validation-data-path` CLI parameter to load a separate JSONL dataset for validation/evaluation, instead of only deriving eval data from a split of the training data via `--validation-split`
- The new flag is mutually exclusive with `--validation-split` and requires `--validation-frequency` to be set
- Supports both instruction-tuning (JsonlDataset) and pretraining (PretrainingBlockDataset) modes

## Files Changed
- `src/mini_trainer/training_types.py` — new `validation_data_path` field on `TrainingArgs`
- `src/mini_trainer/sampler.py` — `get_data_loader()` accepts and loads a separate validation dataset
- `src/mini_trainer/train.py` — CLI param, mutual exclusivity validation, forwarding to `get_data_loader`
- `src/mini_trainer/api_train.py` — forwards `validation_data_path` to the torchrun subprocess command

## Test plan
- [x] Added 3 new unit tests in `test_data_loader.py`: separate dataset loading, mutual exclusivity, no-split behavior
- [x] Added 1 new unit test in `test_api_train.py`: command construction with `validation_data_path`
- [x] All 69 data-loader and API tests pass (243 total non-GPU tests pass)
- [x] Pre-existing ruff F821 error in `train.py:850` is unchanged from `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)