### PR TITLE
feat: replace frequency-based validation with configurable event-based system

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -28,6 +28,7 @@
 - ♾️ **Infinite Sampling** - Continuous data streaming without manual epoch configuration
 - 🔬 **Orthogonal Subspace Fine-Tuning (OSFT)** - Advanced continual learning technique for parameter-efficient training
 - 📚 **Pretraining Mode** - Document-style pretraining with configurable block sizes on pre-tokenized `input_ids`
+- ✅ **Event-Based Validation** - Configurable validation triggers (step, epoch, sample-count, end-of-training) with best-loss checkpointing
 - 📊 **Flexible Logging** - JSONL metrics logging with optional Weights & Biases integration
 
 ---
@@ -124,6 +125,11 @@ torchrun --nnodes=1 --nproc-per-node=8 -m mini_trainer.train \
 - `--osft` - Enable Orthogonal Subspace Fine-Tuning mode
 - `--osft-unfreeze-rank-ratio` - Ratio of model parameters to train with OSFT (0.0-1.0)
 - `--block-size` - Enables pretraining mode with the given block length
+- `--validation-split` - Fraction of training data to hold out for validation (0.0-1.0)
+- `--validation-data-path` - Path to a separate validation dataset (mutually exclusive with `--validation-split`)
+- `--validation-frequency` - Run validation every N steps
+- `--validate-at-epoch` - Run validation at the end of each epoch
+- `--validate-at-final` - Run validation at the end of training
 
 For the complete list of arguments and advanced configuration options, see [`src/mini_trainer/api_train.py`](src/mini_trainer/api_train.py).
 
@@ -131,6 +137,90 @@ For the complete list of arguments and advanced configuration options, see [`src
 
 > 🛠️ **Contributors** – Looking for the lazy-init + FSDP2 loading flow?  
 > See [docs/distributed_initialization.md](docs/distributed_initialization.md) for diagrams and a detailed walkthrough of the SFT and OSFT pipelines.
+
+## ✅ Validation
+
+Mini Trainer supports configurable validation during training with an event-based trigger system. You can combine multiple triggers to control exactly when validation runs.
+
+### Providing Validation Data
+
+There are two ways to supply validation data:
+
+1. **Automatic split** — hold out a fraction of the training data:
+   ```bash
+   --validation-split 0.1  # use 10% for validation
+   ```
+
+2. **Separate dataset** — provide a dedicated JSONL file:
+   ```bash
+   --validation-data-path ./eval_data.jsonl
+   ```
+
+These options are mutually exclusive.
+
+### Validation Triggers
+
+At least one trigger must be configured when validation data is provided. Triggers can be combined — for example, validate every 100 steps *and* at the end of each epoch.
+
+| Flag | Description |
+|------|-------------|
+| `--validation-frequency N` | Run validation every **N** training steps |
+| `--validate-at-epoch` | Run validation at the **end of each epoch** |
+| `--min-samples-per-validation N` | Run validation every **N** accumulated samples |
+| `--validate-at-final` | Run validation at the **end of training** |
+
+When both step and sample triggers fire on the same step, validation runs only once (triggers are coalesced).
+
+### Best Validation Loss Checkpointing
+
+Save a checkpoint whenever validation loss improves:
+
+```bash
+--save-best-val-loss \
+--val-loss-improvement-threshold 0.001  # optional minimum improvement
+```
+
+### CLI Example
+
+```bash
+torchrun --nnodes=1 --nproc-per-node=8 -m mini_trainer.train \
+    --model-name-or-path meta-llama/Llama-3.1-8B-Instruct \
+    --data-path ./data.jsonl \
+    --output-dir ./checkpoints \
+    --batch-size 128 \
+    --max-tokens-per-gpu 128000 \
+    --learning-rate 5e-6 \
+    --validation-data-path ./eval_data.jsonl \
+    --validate-at-epoch \
+    --validate-at-final \
+    --save-best-val-loss
+```
+
+### Programmatic API
+
+```python
+from mini_trainer import TrainingArgs, TorchrunArgs, run_training
+
+train_args = TrainingArgs(
+    model_name_or_path="meta-llama/Llama-3.1-8B-Instruct",
+    data_path="./data.jsonl",
+    output_dir="./checkpoints",
+    batch_size=128,
+    max_tokens_per_gpu=128000,
+    learning_rate=5e-6,
+    # Validation configuration
+    validation_data_path="./eval_data.jsonl",
+    validate_at_epoch=True,
+    validate_at_final=True,
+    save_best_val_loss=True,
+)
+
+run_training(TorchrunArgs(nproc_per_node=8), train_args)
+```
+
+Validation state is saved in full-state checkpoints, so training can be resumed without re-running validation from scratch.
+
+---
 
 ## 📊 Data Format
 

--- a/Readme.md
+++ b/Readme.md
@@ -125,10 +125,11 @@ torchrun --nnodes=1 --nproc-per-node=8 -m mini_trainer.train \
 - `--osft` - Enable Orthogonal Subspace Fine-Tuning mode
 - `--osft-unfreeze-rank-ratio` - Ratio of model parameters to train with OSFT (0.0-1.0)
 - `--block-size` - Enables pretraining mode with the given block length
-- `--validation-split` - Fraction of training data to hold out for validation (0.0-1.0)
+- `--validation-split` - Fraction of training data to hold out for validation (greater than 0, less than 1)
 - `--validation-data-path` - Path to a separate validation dataset (mutually exclusive with `--validation-split`)
 - `--validation-frequency` - Run validation every N steps
 - `--validate-at-epoch` - Run validation at the end of each epoch
+- `--min-samples-per-validation` - Minimum accumulated samples between validation runs
 - `--validate-at-final` - Run validation at the end of training
 
 For the complete list of arguments and advanced configuration options, see [`src/mini_trainer/api_train.py`](src/mini_trainer/api_train.py).

--- a/src/mini_trainer/api_train.py
+++ b/src/mini_trainer/api_train.py
@@ -156,6 +156,21 @@ def run_training(torch_args: TorchrunArgs, train_args: TrainingArgs) -> None:
 
     has_validation = train_args.validation_split > 0.0 or train_args.validation_data_path is not None
     if has_validation:
+        has_trigger = (
+            (train_args.validation_frequency is not None and train_args.validation_frequency > 0)
+            or train_args.validate_at_epoch
+            or (train_args.min_samples_per_validation is not None and train_args.min_samples_per_validation > 0)
+            or train_args.validate_at_final
+        )
+        if not has_trigger:
+            raise ValueError(
+                "Validation data is provided but no validation trigger is configured. "
+                "Set at least one of: validation_frequency, validate_at_epoch, "
+                "min_samples_per_validation, or validate_at_final."
+            )
+        if train_args.min_samples_per_validation is not None and train_args.min_samples_per_validation < 1:
+            raise ValueError("min_samples_per_validation must be a positive integer when set")
+
         if train_args.validation_frequency is not None:
             command.append(f"--validation-frequency={train_args.validation_frequency}")
         if train_args.validate_at_epoch:

--- a/src/mini_trainer/api_train.py
+++ b/src/mini_trainer/api_train.py
@@ -158,6 +158,12 @@ def run_training(torch_args: TorchrunArgs, train_args: TrainingArgs) -> None:
     if has_validation:
         if train_args.validation_frequency is not None:
             command.append(f"--validation-frequency={train_args.validation_frequency}")
+        if train_args.validate_at_epoch:
+            command.append("--validate-at-epoch")
+        if train_args.min_samples_per_validation is not None:
+            command.append(f"--min-samples-per-validation={train_args.min_samples_per_validation}")
+        if train_args.validate_at_final:
+            command.append("--validate-at-final")
 
         if train_args.save_best_val_loss:
             command.append("--save-best-val-loss")

--- a/src/mini_trainer/api_train.py
+++ b/src/mini_trainer/api_train.py
@@ -156,6 +156,8 @@ def run_training(torch_args: TorchrunArgs, train_args: TrainingArgs) -> None:
 
     has_validation = train_args.validation_split > 0.0 or train_args.validation_data_path is not None
     if has_validation:
+        if train_args.min_samples_per_validation is not None and train_args.min_samples_per_validation < 1:
+            raise ValueError("min_samples_per_validation must be a positive integer when set")
         has_trigger = (
             (train_args.validation_frequency is not None and train_args.validation_frequency > 0)
             or train_args.validate_at_epoch
@@ -168,8 +170,6 @@ def run_training(torch_args: TorchrunArgs, train_args: TrainingArgs) -> None:
                 "Set at least one of: validation_frequency, validate_at_epoch, "
                 "min_samples_per_validation, or validate_at_final."
             )
-        if train_args.min_samples_per_validation is not None and train_args.min_samples_per_validation < 1:
-            raise ValueError("min_samples_per_validation must be a positive integer when set")
 
         if train_args.validation_frequency is not None:
             command.append(f"--validation-frequency={train_args.validation_frequency}")

--- a/src/mini_trainer/train.py
+++ b/src/mini_trainer/train.py
@@ -1639,10 +1639,12 @@ def main(
         raise ValueError("validation_data_path and validation_split are mutually exclusive")
 
     has_validation = validation_split > 0.0 or validation_data_path is not None
+    if has_validation and min_samples_per_validation is not None and min_samples_per_validation < 1:
+        raise ValueError("min_samples_per_validation must be a positive integer when set")
     has_validation_trigger = (
         (validation_frequency is not None and validation_frequency > 0)
         or validate_at_epoch
-        or min_samples_per_validation is not None
+        or (min_samples_per_validation is not None and min_samples_per_validation > 0)
         or validate_at_final
     )
     if has_validation and not has_validation_trigger:

--- a/src/mini_trainer/train.py
+++ b/src/mini_trainer/train.py
@@ -35,6 +35,7 @@ from mini_trainer.utils import (
 logging.getLogger("httpx").setLevel(logging.WARNING)
 
 SaveType = Literal["min_samples", "epoch", "final", "best_val_loss"]
+ValidationType = Literal["step", "epoch", "samples", "final"]
 
 app = Typer(
     pretty_exceptions_enable=False,  # disable rich exception formatting
@@ -662,6 +663,84 @@ class Checkpointer:
             log_rank_0(f"New best validation loss: {val_loss:.6f}")
 
 
+class ValidationScheduler:
+    """
+    A stateful scheduler that manages when to run validation, mirroring the
+    Checkpointer's event-based design.
+
+    Supports four trigger types:
+    - step: Validate every N training steps
+    - epoch: Validate at the end of each epoch
+    - samples: Validate every N accumulated samples
+    - final: Validate at the end of training
+    """
+
+    def __init__(
+        self,
+        validation_frequency: int | None = None,
+        validate_at_epoch: bool = False,
+        min_samples_per_validation: int | None = None,
+        validate_at_final: bool = False,
+    ):
+        self.validation_frequency = validation_frequency
+        self.validate_at_epoch = validate_at_epoch
+        self.min_samples_per_validation = min_samples_per_validation
+        self.validate_at_final = validate_at_final
+
+        self.last_validated_samples = 0
+        self.last_sample_based_validation_samples = 0
+
+    @property
+    def is_configured(self) -> bool:
+        return (
+            self.validation_frequency is not None
+            or self.validate_at_epoch
+            or self.min_samples_per_validation is not None
+            or self.validate_at_final
+        )
+
+    def should_validate(
+        self,
+        validation_type: ValidationType,
+        step: int = 0,
+        accumulated_samples: int = 0,
+        end_of_epoch: bool = False,
+        end_of_training: bool = False,
+    ) -> bool:
+        match validation_type:
+            case "step":
+                return (
+                    self.validation_frequency is not None
+                    and self.validation_frequency > 0
+                    and step % self.validation_frequency == 0
+                )
+
+            case "epoch":
+                if not self.validate_at_epoch or not end_of_epoch:
+                    return False
+                return accumulated_samples > self.last_validated_samples
+
+            case "samples":
+                return (
+                    self.min_samples_per_validation is not None
+                    and accumulated_samples
+                    >= self.last_sample_based_validation_samples + self.min_samples_per_validation
+                )
+
+            case "final":
+                if not self.validate_at_final or not end_of_training:
+                    return False
+                return accumulated_samples > self.last_validated_samples
+
+            case _:
+                raise ValueError(f"Unknown validation type: {validation_type}")
+
+    def record_validation(self, validation_type: ValidationType, accumulated_samples: int):
+        self.last_validated_samples = accumulated_samples
+        if validation_type == "samples":
+            self.last_sample_based_validation_samples = accumulated_samples
+
+
 def train(
     model: torch.nn.Module,
     optimizer: torch.optim.Optimizer,
@@ -683,6 +762,9 @@ def train(
     use_mlflow: bool = False,
     val_data_loader: torch.utils.data.DataLoader | None = None,
     validation_frequency: int | None = None,
+    validate_at_epoch: bool = False,
+    min_samples_per_validation: int | None = None,
+    validate_at_final: bool = False,
     trust_remote_code: bool = False,
     on_demand_checkpointing: bool = False,
     resume_from_full_state_checkpoint: str | None = None,
@@ -763,6 +845,13 @@ def train(
         checkpoint_at_final=save_final_checkpoint,
     )
 
+    validation_scheduler = ValidationScheduler(
+        validation_frequency=validation_frequency,
+        validate_at_epoch=validate_at_epoch,
+        min_samples_per_validation=min_samples_per_validation,
+        validate_at_final=validate_at_final,
+    )
+
     # Initialize on-demand full-state checkpointing if enabled
     full_state_checkpointer = None
     if on_demand_checkpointing:
@@ -805,6 +894,12 @@ def train(
         checkpointer.last_saved_samples = cs["last_saved_samples"]
         checkpointer.last_frequency_saved_samples = cs["last_frequency_saved_samples"]
         checkpointer.best_val_loss = cs["best_val_loss"]
+
+        # Restore validation scheduler state
+        vs = meta.get("validation_scheduler_state")
+        if vs:
+            validation_scheduler.last_validated_samples = vs["last_validated_samples"]
+            validation_scheduler.last_sample_based_validation_samples = vs["last_sample_based_validation_samples"]
 
         # Restore LR scheduler
         lr_scheduler.load_state_dict(meta["lr_scheduler_state"])
@@ -984,6 +1079,10 @@ def train(
                         "total_samples_accumulated": total_samples_accumulated,
                         "total_tokens_processed": total_tokens_processed,
                         "last_validation_loss": last_validation_loss,
+                        "validation_scheduler_state": {
+                            "last_validated_samples": validation_scheduler.last_validated_samples,
+                            "last_sample_based_validation_samples": validation_scheduler.last_sample_based_validation_samples,
+                        },
                     },
                     checkpointer_state={
                         "last_saved_samples": checkpointer.last_saved_samples,
@@ -1055,13 +1154,30 @@ def train(
                 "peak_memory_usage_GB": float(torch.cuda.max_memory_allocated() / 1e9),
                 "val_loss": last_validation_loss,
             }
-            # Add validation metrics if it's time to validate
-            if val_data_loader is not None and validation_frequency is not None and step % validation_frequency == 0:
+            # Event-based validation: step trigger
+            if val_data_loader is not None and validation_scheduler.should_validate(
+                "step", step=step, accumulated_samples=total_samples_accumulated
+            ):
                 val_metrics = compute_validation_loss(model, val_data_loader, device)
                 if val_metrics and "val_loss" in val_metrics:
                     last_validation_loss = val_metrics["val_loss"]
                     print(f"Validation loss: {last_validation_loss}")
                 batch_metrics.update(val_metrics)
+                validation_scheduler.record_validation("step", total_samples_accumulated)
+
+                if callback_manager:
+                    callback_manager.fire("on_evaluate", val_metrics=val_metrics)
+
+            # Event-based validation: sample trigger
+            if val_data_loader is not None and validation_scheduler.should_validate(
+                "samples", accumulated_samples=total_samples_accumulated
+            ):
+                val_metrics = compute_validation_loss(model, val_data_loader, device)
+                if val_metrics and "val_loss" in val_metrics:
+                    last_validation_loss = val_metrics["val_loss"]
+                    print(f"Validation loss: {last_validation_loss}")
+                batch_metrics.update(val_metrics)
+                validation_scheduler.record_validation("samples", total_samples_accumulated)
 
                 if callback_manager:
                     callback_manager.fire("on_evaluate", val_metrics=val_metrics)
@@ -1090,6 +1206,10 @@ def train(
                         "total_samples_accumulated": total_samples_accumulated,
                         "total_tokens_processed": total_tokens_processed,
                         "last_validation_loss": last_validation_loss,
+                        "validation_scheduler_state": {
+                            "last_validated_samples": validation_scheduler.last_validated_samples,
+                            "last_sample_based_validation_samples": validation_scheduler.last_sample_based_validation_samples,
+                        },
                     },
                     checkpointer_state={
                         "last_saved_samples": checkpointer.last_saved_samples,
@@ -1166,6 +1286,40 @@ def train(
         if callback_manager:
             callback_manager.context.epoch = epoch
 
+        # Event-based validation: epoch trigger
+        if val_data_loader is not None and validation_scheduler.should_validate(
+            "epoch", accumulated_samples=total_samples_accumulated, end_of_epoch=True
+        ):
+            val_metrics = compute_validation_loss(model, val_data_loader, device)
+            if val_metrics and "val_loss" in val_metrics:
+                last_validation_loss = val_metrics["val_loss"]
+                log_rank_0(f"Epoch {epoch} validation loss: {last_validation_loss}")
+            validation_scheduler.record_validation("epoch", total_samples_accumulated)
+
+            if callback_manager:
+                callback_manager.fire("on_evaluate", val_metrics=val_metrics)
+
+            if checkpointer.should_save_checkpoint(
+                save_type="best_val_loss",
+                accumulated_samples=total_samples_accumulated,
+                val_loss=last_validation_loss,
+            ):
+                save_model(
+                    model,
+                    total_samples_accumulated,
+                    output_dir,
+                    model_name_or_path,
+                    suffix="best_val_loss",
+                    trust_remote_code=trust_remote_code,
+                )
+                checkpointer.record_save("best_val_loss", total_samples_accumulated, last_validation_loss)
+
+                if callback_manager:
+                    _ckpt = str(
+                        Path(output_dir) / "hf_format" / f"samples_{total_samples_accumulated}_best_val_loss"
+                    )
+                    callback_manager.fire("on_save", checkpoint_path=_ckpt)
+
         # save at the current number of samples seen
         # should save at the end of each epoch
         if checkpointer.should_save_checkpoint(
@@ -1190,6 +1344,39 @@ def train(
             callback_manager.fire("on_epoch_end")
 
     torch.distributed.barrier()
+
+    # Event-based validation: final trigger
+    if val_data_loader is not None and validation_scheduler.should_validate(
+        "final", accumulated_samples=total_samples_accumulated, end_of_training=True
+    ):
+        val_metrics = compute_validation_loss(model, val_data_loader, device)
+        if val_metrics and "val_loss" in val_metrics:
+            last_validation_loss = val_metrics["val_loss"]
+            log_rank_0(f"Final validation loss: {last_validation_loss}")
+        validation_scheduler.record_validation("final", total_samples_accumulated)
+
+        if callback_manager:
+            callback_manager.fire("on_evaluate", val_metrics=val_metrics)
+
+        if checkpointer.should_save_checkpoint(
+            save_type="best_val_loss",
+            accumulated_samples=total_samples_accumulated,
+            val_loss=last_validation_loss,
+        ):
+            save_model(
+                model,
+                total_samples_accumulated,
+                output_dir,
+                model_name_or_path,
+                suffix="best_val_loss",
+                trust_remote_code=trust_remote_code,
+            )
+            checkpointer.record_save("best_val_loss", total_samples_accumulated, last_validation_loss)
+
+            if callback_manager:
+                _ckpt = str(Path(output_dir) / "hf_format" / f"samples_{total_samples_accumulated}_best_val_loss")
+                callback_manager.fire("on_save", checkpoint_path=_ckpt)
+
     # save one last time if we haven't yet
     if checkpointer.should_save_checkpoint(
         save_type="final",
@@ -1344,9 +1531,19 @@ def main(
     validation_frequency: Annotated[
         int | None,
         Option(
-            help="Frequency of validation evaluation (in steps). Required when validation_split > 0 or validation_data_path is provided"
+            help="Run validation every N training steps. At least one validation trigger must be set when validation data is provided"
         ),
     ] = None,
+    validate_at_epoch: Annotated[
+        bool, Option(help="Whether to run validation at the end of each epoch")
+    ] = False,
+    min_samples_per_validation: Annotated[
+        int | None,
+        Option(help="Minimum number of accumulated samples between validation runs"),
+    ] = None,
+    validate_at_final: Annotated[
+        bool, Option(help="Whether to run validation at the end of training")
+    ] = False,
     # checkpoint parameters
     save_best_val_loss: Annotated[
         bool, Option(help="Whether to save checkpoints when validation loss improves")
@@ -1428,8 +1625,17 @@ def main(
         raise ValueError("validation_data_path and validation_split are mutually exclusive")
 
     has_validation = validation_split > 0.0 or validation_data_path is not None
-    if has_validation and (validation_frequency is None or validation_frequency <= 0):
-        raise ValueError("validation_frequency must be provided and positive when using validation")
+    has_validation_trigger = (
+        (validation_frequency is not None and validation_frequency > 0)
+        or validate_at_epoch
+        or min_samples_per_validation is not None
+        or validate_at_final
+    )
+    if has_validation and not has_validation_trigger:
+        raise ValueError(
+            "At least one validation trigger must be configured when validation data is provided: "
+            "validation_frequency, validate_at_epoch, min_samples_per_validation, or validate_at_final"
+        )
 
     # Convert string dtypes to torch dtypes
     osft_upcast_dtype_torch = parse_dtype(osft_upcast_dtype)
@@ -1473,6 +1679,9 @@ def main(
             "validation_split": validation_split,
             "validation_data_path": validation_data_path,
             "validation_frequency": validation_frequency,
+            "validate_at_epoch": validate_at_epoch,
+            "min_samples_per_validation": min_samples_per_validation,
+            "validate_at_final": validate_at_final,
             "save_best_val_loss": save_best_val_loss,
             "val_loss_improvement_threshold": val_loss_improvement_threshold,
             "wandb_project": wandb_project,
@@ -1661,6 +1870,9 @@ def main(
         use_mlflow=use_mlflow,
         val_data_loader=val_data_loader,
         validation_frequency=validation_frequency,
+        validate_at_epoch=validate_at_epoch,
+        min_samples_per_validation=min_samples_per_validation,
+        validate_at_final=validate_at_final,
         trust_remote_code=trust_remote_code,
         on_demand_checkpointing=on_demand_checkpointing,
         resume_from_full_state_checkpoint=resume_from_full_state_checkpoint,

--- a/src/mini_trainer/train.py
+++ b/src/mini_trainer/train.py
@@ -682,6 +682,11 @@ class ValidationScheduler:
         min_samples_per_validation: int | None = None,
         validate_at_final: bool = False,
     ):
+        if validation_frequency is not None and validation_frequency < 1:
+            validation_frequency = None
+        if min_samples_per_validation is not None and min_samples_per_validation < 1:
+            raise ValueError("min_samples_per_validation must be a positive integer when set")
+
         self.validation_frequency = validation_frequency
         self.validate_at_epoch = validate_at_epoch
         self.min_samples_per_validation = min_samples_per_validation
@@ -689,13 +694,15 @@ class ValidationScheduler:
 
         self.last_validated_samples = 0
         self.last_sample_based_validation_samples = 0
+        self.last_epoch_validated_samples = 0
+        self.last_final_validated_samples = 0
 
     @property
     def is_configured(self) -> bool:
         return (
-            self.validation_frequency is not None
+            (self.validation_frequency is not None and self.validation_frequency > 0)
             or self.validate_at_epoch
-            or self.min_samples_per_validation is not None
+            or (self.min_samples_per_validation is not None and self.min_samples_per_validation > 0)
             or self.validate_at_final
         )
 
@@ -712,17 +719,19 @@ class ValidationScheduler:
                 return (
                     self.validation_frequency is not None
                     and self.validation_frequency > 0
+                    and step > 0
                     and step % self.validation_frequency == 0
                 )
 
             case "epoch":
                 if not self.validate_at_epoch or not end_of_epoch:
                     return False
-                return accumulated_samples > self.last_validated_samples
+                return accumulated_samples > self.last_epoch_validated_samples
 
             case "samples":
                 return (
                     self.min_samples_per_validation is not None
+                    and self.min_samples_per_validation > 0
                     and accumulated_samples
                     >= self.last_sample_based_validation_samples + self.min_samples_per_validation
                 )
@@ -730,7 +739,7 @@ class ValidationScheduler:
             case "final":
                 if not self.validate_at_final or not end_of_training:
                     return False
-                return accumulated_samples > self.last_validated_samples
+                return accumulated_samples > self.last_final_validated_samples
 
             case _:
                 raise ValueError(f"Unknown validation type: {validation_type}")
@@ -739,6 +748,10 @@ class ValidationScheduler:
         self.last_validated_samples = accumulated_samples
         if validation_type == "samples":
             self.last_sample_based_validation_samples = accumulated_samples
+        elif validation_type == "epoch":
+            self.last_epoch_validated_samples = accumulated_samples
+        elif validation_type == "final":
+            self.last_final_validated_samples = accumulated_samples
 
 
 def train(
@@ -852,6 +865,13 @@ def train(
         validate_at_final=validate_at_final,
     )
 
+    if val_data_loader is not None and not validation_scheduler.is_configured:
+        raise ValueError(
+            "Validation data is provided but no validation trigger is configured. "
+            "Set at least one of: --validation-frequency, --validate-at-epoch, "
+            "--min-samples-per-validation, or --validate-at-final."
+        )
+
     # Initialize on-demand full-state checkpointing if enabled
     full_state_checkpointer = None
     if on_demand_checkpointing:
@@ -900,6 +920,8 @@ def train(
         if vs:
             validation_scheduler.last_validated_samples = vs["last_validated_samples"]
             validation_scheduler.last_sample_based_validation_samples = vs["last_sample_based_validation_samples"]
+            validation_scheduler.last_epoch_validated_samples = vs.get("last_epoch_validated_samples", 0)
+            validation_scheduler.last_final_validated_samples = vs.get("last_final_validated_samples", 0)
 
         # Restore LR scheduler
         lr_scheduler.load_state_dict(meta["lr_scheduler_state"])
@@ -1082,6 +1104,8 @@ def train(
                         "validation_scheduler_state": {
                             "last_validated_samples": validation_scheduler.last_validated_samples,
                             "last_sample_based_validation_samples": validation_scheduler.last_sample_based_validation_samples,
+                            "last_epoch_validated_samples": validation_scheduler.last_epoch_validated_samples,
+                            "last_final_validated_samples": validation_scheduler.last_final_validated_samples,
                         },
                     },
                     checkpointer_state={
@@ -1154,33 +1178,27 @@ def train(
                 "peak_memory_usage_GB": float(torch.cuda.max_memory_allocated() / 1e9),
                 "val_loss": last_validation_loss,
             }
-            # Event-based validation: step trigger
-            if val_data_loader is not None and validation_scheduler.should_validate(
-                "step", step=step, accumulated_samples=total_samples_accumulated
-            ):
-                val_metrics = compute_validation_loss(model, val_data_loader, device)
-                if val_metrics and "val_loss" in val_metrics:
-                    last_validation_loss = val_metrics["val_loss"]
-                    print(f"Validation loss: {last_validation_loss}")
-                batch_metrics.update(val_metrics)
-                validation_scheduler.record_validation("step", total_samples_accumulated)
+            # Event-based validation: coalesce step and sample triggers (run at most once per step)
+            if val_data_loader is not None:
+                step_triggered = validation_scheduler.should_validate(
+                    "step", step=step, accumulated_samples=total_samples_accumulated
+                )
+                sample_triggered = validation_scheduler.should_validate(
+                    "samples", accumulated_samples=total_samples_accumulated
+                )
+                if step_triggered or sample_triggered:
+                    val_metrics = compute_validation_loss(model, val_data_loader, device)
+                    if val_metrics and "val_loss" in val_metrics:
+                        last_validation_loss = val_metrics["val_loss"]
+                        log_rank_0(f"Validation loss: {last_validation_loss}")
+                    batch_metrics.update(val_metrics)
+                    if step_triggered:
+                        validation_scheduler.record_validation("step", total_samples_accumulated)
+                    if sample_triggered:
+                        validation_scheduler.record_validation("samples", total_samples_accumulated)
 
-                if callback_manager:
-                    callback_manager.fire("on_evaluate", val_metrics=val_metrics)
-
-            # Event-based validation: sample trigger
-            if val_data_loader is not None and validation_scheduler.should_validate(
-                "samples", accumulated_samples=total_samples_accumulated
-            ):
-                val_metrics = compute_validation_loss(model, val_data_loader, device)
-                if val_metrics and "val_loss" in val_metrics:
-                    last_validation_loss = val_metrics["val_loss"]
-                    print(f"Validation loss: {last_validation_loss}")
-                batch_metrics.update(val_metrics)
-                validation_scheduler.record_validation("samples", total_samples_accumulated)
-
-                if callback_manager:
-                    callback_manager.fire("on_evaluate", val_metrics=val_metrics)
+                    if callback_manager:
+                        callback_manager.fire("on_evaluate", val_metrics=val_metrics)
 
             if callback_manager:
                 callback_manager.context.loss = logged_loss
@@ -1209,6 +1227,8 @@ def train(
                         "validation_scheduler_state": {
                             "last_validated_samples": validation_scheduler.last_validated_samples,
                             "last_sample_based_validation_samples": validation_scheduler.last_sample_based_validation_samples,
+                            "last_epoch_validated_samples": validation_scheduler.last_epoch_validated_samples,
+                            "last_final_validated_samples": validation_scheduler.last_final_validated_samples,
                         },
                     },
                     checkpointer_state={

--- a/src/mini_trainer/train.py
+++ b/src/mini_trainer/train.py
@@ -1315,9 +1315,7 @@ def train(
                 checkpointer.record_save("best_val_loss", total_samples_accumulated, last_validation_loss)
 
                 if callback_manager:
-                    _ckpt = str(
-                        Path(output_dir) / "hf_format" / f"samples_{total_samples_accumulated}_best_val_loss"
-                    )
+                    _ckpt = str(Path(output_dir) / "hf_format" / f"samples_{total_samples_accumulated}_best_val_loss")
                     callback_manager.fire("on_save", checkpoint_path=_ckpt)
 
         # save at the current number of samples seen
@@ -1534,16 +1532,12 @@ def main(
             help="Run validation every N training steps. At least one validation trigger must be set when validation data is provided"
         ),
     ] = None,
-    validate_at_epoch: Annotated[
-        bool, Option(help="Whether to run validation at the end of each epoch")
-    ] = False,
+    validate_at_epoch: Annotated[bool, Option(help="Whether to run validation at the end of each epoch")] = False,
     min_samples_per_validation: Annotated[
         int | None,
         Option(help="Minimum number of accumulated samples between validation runs"),
     ] = None,
-    validate_at_final: Annotated[
-        bool, Option(help="Whether to run validation at the end of training")
-    ] = False,
+    validate_at_final: Annotated[bool, Option(help="Whether to run validation at the end of training")] = False,
     # checkpoint parameters
     save_best_val_loss: Annotated[
         bool, Option(help="Whether to save checkpoints when validation loss improves")

--- a/src/mini_trainer/training_types.py
+++ b/src/mini_trainer/training_types.py
@@ -190,8 +190,22 @@ class TrainingArgs:
     validation_frequency: int | None = field(
         default=None,
         metadata={
-            "help": "The frequency of validation in steps. Required when validation_split > 0 or validation_data_path is provided."
+            "help": "Run validation every N training steps. One of the event-based validation triggers "
+            "(validation_frequency, validate_at_epoch, min_samples_per_validation, validate_at_final) "
+            "must be configured when validation data is provided."
         },
+    )
+    validate_at_epoch: bool = field(
+        default=False,
+        metadata={"help": "Whether to run validation at the end of each epoch."},
+    )
+    min_samples_per_validation: int | None = field(
+        default=None,
+        metadata={"help": "Minimum number of accumulated samples between validation runs."},
+    )
+    validate_at_final: bool = field(
+        default=False,
+        metadata={"help": "Whether to run validation at the end of training."},
     )
 
     # Pretraining configuration (None = instruction tuning, non-None = pretraining)

--- a/tests/test_api_train.py
+++ b/tests/test_api_train.py
@@ -584,6 +584,153 @@ class TestRunTraining:
             assert "--validate-at-final" in command
             assert "--validation-split=0.1" in command
 
+    def test_run_training_validation_data_without_trigger_raises(self):
+        """Test that validation data without any trigger raises ValueError."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            torch_args = TorchrunArgs(nproc_per_node=1)
+            train_args = TrainingArgs(
+                model_name_or_path="test-model",
+                data_path="train.jsonl",
+                batch_size=32,
+                max_tokens_per_gpu=1000,
+                learning_rate=1e-5,
+                output_dir=tmpdir,
+                validation_data_path="/data/eval.jsonl",
+            )
+
+            with pytest.raises(ValueError, match="no validation trigger is configured"):
+                run_training(torch_args, train_args)
+
+    def test_run_training_validation_split_without_trigger_raises(self):
+        """Test that validation split without any trigger raises ValueError."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            torch_args = TorchrunArgs(nproc_per_node=1)
+            train_args = TrainingArgs(
+                model_name_or_path="test-model",
+                data_path="train.jsonl",
+                batch_size=32,
+                max_tokens_per_gpu=1000,
+                learning_rate=1e-5,
+                output_dir=tmpdir,
+                validation_split=0.1,
+            )
+
+            with pytest.raises(ValueError, match="no validation trigger is configured"):
+                run_training(torch_args, train_args)
+
+    def test_run_training_min_samples_per_validation_zero_raises(self):
+        """Test that min_samples_per_validation=0 raises ValueError when another trigger is set."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            torch_args = TorchrunArgs(nproc_per_node=1)
+            train_args = TrainingArgs(
+                model_name_or_path="test-model",
+                data_path="train.jsonl",
+                batch_size=32,
+                max_tokens_per_gpu=1000,
+                learning_rate=1e-5,
+                output_dir=tmpdir,
+                validation_split=0.1,
+                validate_at_epoch=True,
+                min_samples_per_validation=0,
+            )
+
+            with pytest.raises(ValueError, match="positive integer"):
+                run_training(torch_args, train_args)
+
+    def test_run_training_min_samples_per_validation_negative_raises(self):
+        """Test that negative min_samples_per_validation raises ValueError."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            torch_args = TorchrunArgs(nproc_per_node=1)
+            train_args = TrainingArgs(
+                model_name_or_path="test-model",
+                data_path="train.jsonl",
+                batch_size=32,
+                max_tokens_per_gpu=1000,
+                learning_rate=1e-5,
+                output_dir=tmpdir,
+                validation_data_path="/data/eval.jsonl",
+                validate_at_final=True,
+                min_samples_per_validation=-5,
+            )
+
+            with pytest.raises(ValueError, match="positive integer"):
+                run_training(torch_args, train_args)
+
+    @patch("mini_trainer.api_train.StreamablePopen")
+    def test_run_training_validation_data_path_with_epoch_trigger(self, mock_popen_class):
+        """Test validation_data_path with epoch trigger passes validation."""
+        mock_popen = MagicMock()
+        mock_popen.poll.return_value = 0
+        mock_popen_class.return_value = mock_popen
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            torch_args = TorchrunArgs(nproc_per_node=1)
+            train_args = TrainingArgs(
+                model_name_or_path="test-model",
+                data_path="train.jsonl",
+                batch_size=32,
+                max_tokens_per_gpu=1000,
+                learning_rate=1e-5,
+                output_dir=tmpdir,
+                validation_data_path="/data/eval.jsonl",
+                validate_at_epoch=True,
+            )
+
+            run_training(torch_args, train_args)
+
+            call_args = mock_popen_class.call_args
+            _, command = call_args[0]
+            assert "--validation-data-path=/data/eval.jsonl" in command
+            assert "--validate-at-epoch" in command
+
+    @patch("mini_trainer.api_train.StreamablePopen")
+    def test_run_training_validation_data_path_with_final_trigger(self, mock_popen_class):
+        """Test validation_data_path with final trigger passes validation."""
+        mock_popen = MagicMock()
+        mock_popen.poll.return_value = 0
+        mock_popen_class.return_value = mock_popen
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            torch_args = TorchrunArgs(nproc_per_node=1)
+            train_args = TrainingArgs(
+                model_name_or_path="test-model",
+                data_path="train.jsonl",
+                batch_size=32,
+                max_tokens_per_gpu=1000,
+                learning_rate=1e-5,
+                output_dir=tmpdir,
+                validation_data_path="/data/eval.jsonl",
+                validate_at_final=True,
+            )
+
+            run_training(torch_args, train_args)
+
+            call_args = mock_popen_class.call_args
+            _, command = call_args[0]
+            assert "--validation-data-path=/data/eval.jsonl" in command
+            assert "--validate-at-final" in command
+
+    @patch("mini_trainer.api_train.StreamablePopen")
+    def test_run_training_no_validation_data_skips_trigger_check(self, mock_popen_class):
+        """Test that no validation data means no trigger check."""
+        mock_popen = MagicMock()
+        mock_popen.poll.return_value = 0
+        mock_popen_class.return_value = mock_popen
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            torch_args = TorchrunArgs(nproc_per_node=1)
+            train_args = TrainingArgs(
+                model_name_or_path="test-model",
+                data_path="train.jsonl",
+                batch_size=32,
+                max_tokens_per_gpu=1000,
+                learning_rate=1e-5,
+                output_dir=tmpdir,
+            )
+
+            run_training(torch_args, train_args)
+            assert mock_popen_class.called
+
     @patch("mini_trainer.api_train.StreamablePopen")
     def test_run_training_keyboard_interrupt(self, mock_popen_class):
         """Test that run_training handles keyboard interrupt properly."""

--- a/tests/test_api_train.py
+++ b/tests/test_api_train.py
@@ -619,7 +619,7 @@ class TestRunTraining:
                 run_training(torch_args, train_args)
 
     def test_run_training_min_samples_per_validation_zero_raises(self):
-        """Test that min_samples_per_validation=0 raises ValueError when another trigger is set."""
+        """Test that min_samples_per_validation=0 raises ValueError even as sole trigger."""
         with tempfile.TemporaryDirectory() as tmpdir:
             torch_args = TorchrunArgs(nproc_per_node=1)
             train_args = TrainingArgs(
@@ -630,7 +630,6 @@ class TestRunTraining:
                 learning_rate=1e-5,
                 output_dir=tmpdir,
                 validation_split=0.1,
-                validate_at_epoch=True,
                 min_samples_per_validation=0,
             )
 
@@ -638,7 +637,7 @@ class TestRunTraining:
                 run_training(torch_args, train_args)
 
     def test_run_training_min_samples_per_validation_negative_raises(self):
-        """Test that negative min_samples_per_validation raises ValueError."""
+        """Test that negative min_samples_per_validation raises ValueError even as sole trigger."""
         with tempfile.TemporaryDirectory() as tmpdir:
             torch_args = TorchrunArgs(nproc_per_node=1)
             train_args = TrainingArgs(
@@ -649,7 +648,6 @@ class TestRunTraining:
                 learning_rate=1e-5,
                 output_dir=tmpdir,
                 validation_data_path="/data/eval.jsonl",
-                validate_at_final=True,
                 min_samples_per_validation=-5,
             )
 

--- a/tests/test_api_train.py
+++ b/tests/test_api_train.py
@@ -554,6 +554,37 @@ class TestRunTraining:
             assert not any(arg.startswith("--validation-split=") for arg in command)
 
     @patch("mini_trainer.api_train.StreamablePopen")
+    def test_run_training_event_based_validation(self, mock_popen_class):
+        """Test that event-based validation params are forwarded to the training command."""
+        mock_popen = MagicMock()
+        mock_popen.poll.return_value = 0
+        mock_popen_class.return_value = mock_popen
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            torch_args = TorchrunArgs(nproc_per_node=1)
+            train_args = TrainingArgs(
+                model_name_or_path="test-model",
+                data_path="train.jsonl",
+                batch_size=32,
+                max_tokens_per_gpu=1000,
+                learning_rate=1e-5,
+                output_dir=tmpdir,
+                validation_split=0.1,
+                validate_at_epoch=True,
+                min_samples_per_validation=500,
+                validate_at_final=True,
+            )
+
+            run_training(torch_args, train_args)
+
+            call_args = mock_popen_class.call_args
+            _, command = call_args[0]
+            assert "--validate-at-epoch" in command
+            assert "--min-samples-per-validation=500" in command
+            assert "--validate-at-final" in command
+            assert "--validation-split=0.1" in command
+
+    @patch("mini_trainer.api_train.StreamablePopen")
     def test_run_training_keyboard_interrupt(self, mock_popen_class):
         """Test that run_training handles keyboard interrupt properly."""
         mock_popen = MagicMock()

--- a/tests/test_validation_scheduler.py
+++ b/tests/test_validation_scheduler.py
@@ -12,6 +12,10 @@ class TestValidationSchedulerIsConfigured:
         vs = ValidationScheduler(validation_frequency=10)
         assert vs.is_configured
 
+    def test_frequency_zero_not_configured(self):
+        vs = ValidationScheduler(validation_frequency=0)
+        assert not vs.is_configured
+
     def test_epoch_trigger(self):
         vs = ValidationScheduler(validate_at_epoch=True)
         assert vs.is_configured
@@ -44,6 +48,10 @@ class TestStepValidation:
 
     def test_frequency_zero_means_no_validation(self):
         vs = ValidationScheduler(validation_frequency=0)
+        assert not vs.should_validate("step", step=0)
+
+    def test_step_zero_does_not_validate(self):
+        vs = ValidationScheduler(validation_frequency=5)
         assert not vs.should_validate("step", step=0)
 
 
@@ -134,6 +142,18 @@ class TestRecordValidation:
         vs.record_validation("step", 50)
         assert vs.last_sample_based_validation_samples == 0
 
+    def test_record_epoch_updates_epoch_tracker(self):
+        vs = ValidationScheduler(validate_at_epoch=True)
+        vs.record_validation("epoch", 100)
+        assert vs.last_epoch_validated_samples == 100
+        assert vs.last_final_validated_samples == 0
+
+    def test_record_final_updates_final_tracker(self):
+        vs = ValidationScheduler(validate_at_final=True)
+        vs.record_validation("final", 200)
+        assert vs.last_final_validated_samples == 200
+        assert vs.last_epoch_validated_samples == 0
+
 
 class TestUnknownValidationType:
     def test_raises_on_unknown_type(self):
@@ -153,3 +173,33 @@ class TestMultipleTriggers:
         vs = ValidationScheduler(validation_frequency=5, min_samples_per_validation=100)
         vs.record_validation("step", 50)
         assert vs.should_validate("samples", accumulated_samples=100)
+
+    def test_step_validation_does_not_suppress_epoch(self):
+        vs = ValidationScheduler(validation_frequency=5, validate_at_epoch=True)
+        vs.record_validation("step", 100)
+        assert vs.should_validate("epoch", accumulated_samples=100, end_of_epoch=True)
+
+    def test_step_validation_does_not_suppress_final(self):
+        vs = ValidationScheduler(validation_frequency=5, validate_at_final=True)
+        vs.record_validation("step", 100)
+        assert vs.should_validate("final", accumulated_samples=100, end_of_training=True)
+
+    def test_epoch_record_does_not_suppress_final(self):
+        vs = ValidationScheduler(validate_at_epoch=True, validate_at_final=True)
+        vs.record_validation("epoch", 100)
+        assert vs.should_validate("final", accumulated_samples=100, end_of_training=True)
+
+
+class TestBoundsValidation:
+    def test_min_samples_zero_raises(self):
+        with pytest.raises(ValueError, match="positive integer"):
+            ValidationScheduler(min_samples_per_validation=0)
+
+    def test_min_samples_negative_raises(self):
+        with pytest.raises(ValueError, match="positive integer"):
+            ValidationScheduler(min_samples_per_validation=-1)
+
+    def test_frequency_negative_normalizes_to_none(self):
+        vs = ValidationScheduler(validation_frequency=-1)
+        assert vs.validation_frequency is None
+        assert not vs.is_configured

--- a/tests/test_validation_scheduler.py
+++ b/tests/test_validation_scheduler.py
@@ -203,3 +203,117 @@ class TestBoundsValidation:
         vs = ValidationScheduler(validation_frequency=-1)
         assert vs.validation_frequency is None
         assert not vs.is_configured
+
+
+class TestStateSerializationAndRestore:
+    def test_state_roundtrip(self):
+        vs = ValidationScheduler(
+            validation_frequency=5,
+            validate_at_epoch=True,
+            min_samples_per_validation=100,
+            validate_at_final=True,
+        )
+        vs.record_validation("step", 50)
+        vs.record_validation("samples", 200)
+        vs.record_validation("epoch", 300)
+        vs.record_validation("final", 400)
+
+        state = {
+            "last_validated_samples": vs.last_validated_samples,
+            "last_sample_based_validation_samples": vs.last_sample_based_validation_samples,
+            "last_epoch_validated_samples": vs.last_epoch_validated_samples,
+            "last_final_validated_samples": vs.last_final_validated_samples,
+        }
+
+        vs2 = ValidationScheduler(
+            validation_frequency=5,
+            validate_at_epoch=True,
+            min_samples_per_validation=100,
+            validate_at_final=True,
+        )
+        vs2.last_validated_samples = state["last_validated_samples"]
+        vs2.last_sample_based_validation_samples = state["last_sample_based_validation_samples"]
+        vs2.last_epoch_validated_samples = state["last_epoch_validated_samples"]
+        vs2.last_final_validated_samples = state["last_final_validated_samples"]
+
+        assert vs2.last_validated_samples == 400
+        assert vs2.last_sample_based_validation_samples == 200
+        assert vs2.last_epoch_validated_samples == 300
+        assert vs2.last_final_validated_samples == 400
+
+        assert not vs2.should_validate("samples", accumulated_samples=250)
+        assert vs2.should_validate("samples", accumulated_samples=300)
+        assert not vs2.should_validate("epoch", accumulated_samples=300, end_of_epoch=True)
+        assert vs2.should_validate("epoch", accumulated_samples=301, end_of_epoch=True)
+
+    def test_restore_with_defaults_for_missing_keys(self):
+        state = {
+            "last_validated_samples": 100,
+            "last_sample_based_validation_samples": 100,
+        }
+
+        vs = ValidationScheduler(validate_at_epoch=True, validate_at_final=True)
+        vs.last_validated_samples = state["last_validated_samples"]
+        vs.last_sample_based_validation_samples = state["last_sample_based_validation_samples"]
+        vs.last_epoch_validated_samples = state.get("last_epoch_validated_samples", 0)
+        vs.last_final_validated_samples = state.get("last_final_validated_samples", 0)
+
+        assert vs.last_epoch_validated_samples == 0
+        assert vs.last_final_validated_samples == 0
+        assert vs.should_validate("epoch", accumulated_samples=1, end_of_epoch=True)
+        assert vs.should_validate("final", accumulated_samples=1, end_of_training=True)
+
+
+class TestCoalescedValidation:
+    def test_step_and_sample_coalesce(self):
+        vs = ValidationScheduler(validation_frequency=5, min_samples_per_validation=100)
+        step_fires = vs.should_validate("step", step=5, accumulated_samples=100)
+        sample_fires = vs.should_validate("samples", accumulated_samples=100)
+        assert step_fires
+        assert sample_fires
+        vs.record_validation("step", 100)
+        vs.record_validation("samples", 100)
+        assert vs.last_validated_samples == 100
+        assert vs.last_sample_based_validation_samples == 100
+
+    def test_step_fires_sample_does_not(self):
+        vs = ValidationScheduler(validation_frequency=5, min_samples_per_validation=200)
+        assert vs.should_validate("step", step=5, accumulated_samples=50)
+        assert not vs.should_validate("samples", accumulated_samples=50)
+
+    def test_sample_fires_step_does_not(self):
+        vs = ValidationScheduler(validation_frequency=5, min_samples_per_validation=100)
+        assert not vs.should_validate("step", step=3, accumulated_samples=100)
+        assert vs.should_validate("samples", accumulated_samples=100)
+
+    def test_neither_fires(self):
+        vs = ValidationScheduler(validation_frequency=5, min_samples_per_validation=200)
+        assert not vs.should_validate("step", step=3, accumulated_samples=50)
+        assert not vs.should_validate("samples", accumulated_samples=50)
+
+
+class TestValidationSchedulerInitialization:
+    def test_initial_state_is_zero(self):
+        vs = ValidationScheduler(
+            validation_frequency=5,
+            validate_at_epoch=True,
+            min_samples_per_validation=100,
+            validate_at_final=True,
+        )
+        assert vs.last_validated_samples == 0
+        assert vs.last_sample_based_validation_samples == 0
+        assert vs.last_epoch_validated_samples == 0
+        assert vs.last_final_validated_samples == 0
+
+    def test_all_triggers_configured(self):
+        vs = ValidationScheduler(
+            validation_frequency=10,
+            validate_at_epoch=True,
+            min_samples_per_validation=500,
+            validate_at_final=True,
+        )
+        assert vs.is_configured
+        assert vs.validation_frequency == 10
+        assert vs.validate_at_epoch is True
+        assert vs.min_samples_per_validation == 500
+        assert vs.validate_at_final is True

--- a/tests/test_validation_scheduler.py
+++ b/tests/test_validation_scheduler.py
@@ -1,0 +1,155 @@
+import pytest
+
+from mini_trainer.train import ValidationScheduler
+
+
+class TestValidationSchedulerIsConfigured:
+    def test_no_triggers(self):
+        vs = ValidationScheduler()
+        assert not vs.is_configured
+
+    def test_step_trigger(self):
+        vs = ValidationScheduler(validation_frequency=10)
+        assert vs.is_configured
+
+    def test_epoch_trigger(self):
+        vs = ValidationScheduler(validate_at_epoch=True)
+        assert vs.is_configured
+
+    def test_samples_trigger(self):
+        vs = ValidationScheduler(min_samples_per_validation=100)
+        assert vs.is_configured
+
+    def test_final_trigger(self):
+        vs = ValidationScheduler(validate_at_final=True)
+        assert vs.is_configured
+
+
+class TestStepValidation:
+    def test_validates_at_frequency(self):
+        vs = ValidationScheduler(validation_frequency=5)
+        assert vs.should_validate("step", step=5)
+        assert vs.should_validate("step", step=10)
+        assert vs.should_validate("step", step=15)
+
+    def test_does_not_validate_between_steps(self):
+        vs = ValidationScheduler(validation_frequency=5)
+        assert not vs.should_validate("step", step=1)
+        assert not vs.should_validate("step", step=3)
+        assert not vs.should_validate("step", step=7)
+
+    def test_no_frequency_means_no_step_validation(self):
+        vs = ValidationScheduler()
+        assert not vs.should_validate("step", step=5)
+
+    def test_frequency_zero_means_no_validation(self):
+        vs = ValidationScheduler(validation_frequency=0)
+        assert not vs.should_validate("step", step=0)
+
+
+class TestEpochValidation:
+    def test_validates_at_epoch_boundary(self):
+        vs = ValidationScheduler(validate_at_epoch=True)
+        assert vs.should_validate("epoch", accumulated_samples=100, end_of_epoch=True)
+
+    def test_does_not_validate_mid_epoch(self):
+        vs = ValidationScheduler(validate_at_epoch=True)
+        assert not vs.should_validate("epoch", accumulated_samples=100, end_of_epoch=False)
+
+    def test_disabled_means_no_epoch_validation(self):
+        vs = ValidationScheduler(validate_at_epoch=False)
+        assert not vs.should_validate("epoch", accumulated_samples=100, end_of_epoch=True)
+
+    def test_does_not_double_validate_at_same_samples(self):
+        vs = ValidationScheduler(validate_at_epoch=True)
+        assert vs.should_validate("epoch", accumulated_samples=100, end_of_epoch=True)
+        vs.record_validation("epoch", 100)
+        assert not vs.should_validate("epoch", accumulated_samples=100, end_of_epoch=True)
+
+    def test_validates_again_after_new_samples(self):
+        vs = ValidationScheduler(validate_at_epoch=True)
+        vs.record_validation("epoch", 100)
+        assert vs.should_validate("epoch", accumulated_samples=200, end_of_epoch=True)
+
+
+class TestSamplesValidation:
+    def test_validates_after_enough_samples(self):
+        vs = ValidationScheduler(min_samples_per_validation=100)
+        assert vs.should_validate("samples", accumulated_samples=100)
+
+    def test_does_not_validate_before_threshold(self):
+        vs = ValidationScheduler(min_samples_per_validation=100)
+        assert not vs.should_validate("samples", accumulated_samples=50)
+
+    def test_validates_again_after_recording(self):
+        vs = ValidationScheduler(min_samples_per_validation=100)
+        vs.record_validation("samples", 100)
+        assert not vs.should_validate("samples", accumulated_samples=150)
+        assert vs.should_validate("samples", accumulated_samples=200)
+
+    def test_no_min_samples_means_no_validation(self):
+        vs = ValidationScheduler()
+        assert not vs.should_validate("samples", accumulated_samples=1000)
+
+    def test_records_sample_based_tracker(self):
+        vs = ValidationScheduler(min_samples_per_validation=100)
+        vs.record_validation("samples", 100)
+        assert vs.last_sample_based_validation_samples == 100
+        assert vs.last_validated_samples == 100
+
+
+class TestFinalValidation:
+    def test_validates_at_end_of_training(self):
+        vs = ValidationScheduler(validate_at_final=True)
+        assert vs.should_validate("final", accumulated_samples=100, end_of_training=True)
+
+    def test_does_not_validate_before_end(self):
+        vs = ValidationScheduler(validate_at_final=True)
+        assert not vs.should_validate("final", accumulated_samples=100, end_of_training=False)
+
+    def test_disabled_means_no_final_validation(self):
+        vs = ValidationScheduler(validate_at_final=False)
+        assert not vs.should_validate("final", accumulated_samples=100, end_of_training=True)
+
+    def test_does_not_double_validate(self):
+        vs = ValidationScheduler(validate_at_final=True)
+        vs.record_validation("final", 100)
+        assert not vs.should_validate("final", accumulated_samples=100, end_of_training=True)
+
+
+class TestRecordValidation:
+    def test_record_updates_last_validated_samples(self):
+        vs = ValidationScheduler(validation_frequency=5)
+        vs.record_validation("step", 50)
+        assert vs.last_validated_samples == 50
+
+    def test_record_samples_updates_both_trackers(self):
+        vs = ValidationScheduler(min_samples_per_validation=100)
+        vs.record_validation("samples", 200)
+        assert vs.last_validated_samples == 200
+        assert vs.last_sample_based_validation_samples == 200
+
+    def test_record_non_samples_does_not_update_sample_tracker(self):
+        vs = ValidationScheduler(validation_frequency=5)
+        vs.record_validation("step", 50)
+        assert vs.last_sample_based_validation_samples == 0
+
+
+class TestUnknownValidationType:
+    def test_raises_on_unknown_type(self):
+        vs = ValidationScheduler()
+        with pytest.raises(ValueError, match="Unknown validation type"):
+            vs.should_validate("unknown", step=1)
+
+
+class TestMultipleTriggers:
+    def test_step_and_epoch_both_active(self):
+        vs = ValidationScheduler(validation_frequency=5, validate_at_epoch=True)
+        assert vs.is_configured
+        assert vs.should_validate("step", step=5)
+        assert vs.should_validate("epoch", accumulated_samples=100, end_of_epoch=True)
+
+    def test_triggers_are_independent(self):
+        vs = ValidationScheduler(validation_frequency=5, min_samples_per_validation=100)
+        vs.record_validation("step", 50)
+        assert vs.should_validate("samples", accumulated_samples=100)


### PR DESCRIPTION
## Summary

- Adds `ValidationScheduler` class mirroring the existing `Checkpointer`'s event-based design pattern
- Validation can now be triggered by four configurable event types:
  - **step**: validate every N training steps (existing `--validation-frequency` behavior, preserved for backward compatibility)
  - **epoch**: validate at end of each epoch (`--validate-at-epoch`)
  - **samples**: validate every N accumulated samples (`--min-samples-per-validation`)
  - **final**: validate at end of training (`--validate-at-final`)
- The existing `--validation-frequency` remains as the step-based trigger — no breaking changes
- At least one validation trigger must be configured when validation data is provided (previously only `validation_frequency` was accepted)
- `ValidationScheduler` state is saved/restored in full-state checkpoints for correct resume behavior
- Epoch-based and final validation also trigger `best_val_loss` checkpoint saves when applicable

Closes #MT-80

## Test plan

- [x] 29 new unit tests for `ValidationScheduler` covering all 4 event types, state tracking, edge cases, and multi-trigger scenarios
- [x] New API test for event-based validation parameter forwarding (`test_run_training_event_based_validation`)
- [x] Full non-GPU test suite passes: 367 passed, 1 skipped (2 pre-existing OSFT failures unrelated to this change)
- [x] Ruff lint + format checks pass
- [ ] GPU validation with `model_validation.py` pending (to be run by validator agent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added event-driven validation scheduling (by steps, epochs, processed samples, or final completion) with configurable triggers.
  - Expanded training/CLI configuration for epoch-based, minimum-sample-count, and final validation options.
  - Validation progress/state is saved and restored in full-state checkpoints, preserving resume behavior.
  - Multiple applicable triggers are coalesced so validation runs at most once per step.

- **Bug Fixes**
  - Now raises an error when validation data is provided without any validation trigger configured.
  - Enforces `min_samples_per_validation` as an integer ≥ 1.

- **Documentation**
  - Updated validation docs and CLI parameter descriptions to reflect event-based validation and checkpoint behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->